### PR TITLE
infra: codify research triage rubric in CLAUDE.md and research-worker skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,43 @@ uv add --dev <package>    # add dev dependency
 
 `main`
 
+## Research Issue Triage
+
+Every research issue — including follow-ups created by agents — **must pass the triage rubric
+before being dispatched**. Apply it immediately after an agent creates follow-up issues (Step 3
+of the research-worker loop), not at dispatch time.
+
+### Rubric
+
+Score 1 point for each "yes":
+
+1. **Decision impact** — Would not knowing this change an implementation decision in the current milestone?
+2. **Novelty** — Is this genuinely new, not already covered by an existing open or closed issue or doc?
+3. **Risk** — Would not knowing this create a correctness or security risk?
+
+**Score ≥ 2 → keep.** Assign to the active milestone if missing.
+
+**Score < 2 → close with `wont-research` label:**
+```bash
+gh issue close <N> --reason "not planned" \
+  --comment "Closing: score X/3 on research triage rubric. <brief reason>"
+gh issue edit <N> --add-label "wont-research"
+```
+
+### Label Workflow
+
+- Research agents tag their own follow-up issues with `triage` at creation time.
+- The orchestrator reads all `triage`-labelled issues after each merge and scores them.
+- Issues that pass become candidates for the next dispatch batch.
+- Issues that fail are closed immediately — do not leave them open.
+
+### Anti-patterns to reject (score 0 automatically)
+
+- Empirical measurements that belong *inside* an existing research doc
+- Implementation tasks or data collection scripts
+- Topics already answered in a merged research doc
+- Narrow edge cases that don't alter the core design
+
 ## Issue Labels
 
 | Label | Purpose |
@@ -69,3 +106,5 @@ uv add --dev <package>    # add dev dependency
 | `feat:logging` | JSONL logging + cost ledger |
 | `feat:cli` | CLI wiring + skill files |
 | `in-progress` | Currently being worked on (managed by orchestrator) |
+| `triage` | Follow-up issues pending triage decision (applied by research agents) |
+| `wont-research` | Closed by triage gate — below threshold for standalone research |

--- a/src/conductor/skills/research-worker.md
+++ b/src/conductor/skills/research-worker.md
@@ -67,6 +67,11 @@ by a doc. They do NOT exist to track:
 - Be assigned the **same milestone** as the parent issue
 - Represent a topic that warrants a standalone research document
 - Not duplicate an existing open or closed issue
+- Include `triage` in their label list so the orchestrator can find and score them quickly
+
+**All follow-ups are subject to the triage rubric** (see CLAUDE.md "Research Issue Triage").
+The orchestrator applies the rubric immediately after each merge — do not assume follow-ups
+will be dispatched. Issues scoring < 2/3 are closed with `wont-research`.
 
 ### Research Agent Instructions
 
@@ -130,9 +135,10 @@ Launch sub-agents in parallel using `Agent(isolation: "worktree")`.
 >    - Represents a genuinely new architectural/research question
 >    - Is NOT already covered by an existing issue (check: `gh issue list --state all --label research --limit 300 --json number,title`)
 >    - Would require a standalone research document to answer
->    - Use: `gh issue create --title "Research: <topic>" --label research --milestone "<milestone name>" --body "..."`
+>    - Use: `gh issue create --title "Research: <topic>" --label "research,triage" --milestone "<milestone name>" --body "..."`
 >    - Body MUST include: `## Spawned From`, `## Research Areas`, `## Deliverable`, `## Dependencies`
 >    - DO NOT create issues for: implementation tasks, data collection scripts, narrow empirical measurements, things already covered in existing docs
+>    - Add `triage` label to ALL follow-up issues — the orchestrator will score them; don't pre-filter, but be conservative
 > 8. Commit with message referencing the issue: `git commit -m "docs: add <topic> research (Closes #<N>)"`
 > 9. `git push -u origin <branch-name>`
 > 10. Create PR with a full description:
@@ -166,8 +172,17 @@ As **each agent completes** (do not wait for the entire batch):
 2. **Merge the PR**: `gh pr merge <PR-number> --squash --delete-branch`
 3. **Pull**: `git pull origin $DEFAULT_BRANCH`
 4. **Verify follow-ups were created**: check PR body for "Follow-Up Issues Spawned" section
-   - If the agent created follow-ups, review them for quality (not too granular, right milestone)
-   - If the agent created zero follow-ups, read the doc's "Follow-Up Recommendations" section yourself and decide if any warrant issues
+   - If the agent created follow-ups, apply the **triage rubric** to each one immediately:
+     ```bash
+     gh issue list --state open --label triage --limit 50
+     ```
+     For each `triage`-labelled follow-up, score it (3 questions, need ≥2 yes):
+     1. Changes a current-milestone impl decision?
+     2. Genuinely new, not covered by an existing doc or issue?
+     3. Correctness or security risk if skipped?
+     - **Score < 2**: `gh issue close <N> --reason "not planned" --comment "score X/3"` + add `wont-research`
+     - **Score ≥ 2**: `gh issue edit <N> --remove-label triage` (keep, leave in queue)
+   - If the agent created zero follow-ups, read the doc's "Follow-Up Recommendations" section yourself and decide if any warrant issues — if so, create them with `triage` label and score them
 5. **Comment on the closed parent issue**: `gh issue comment <N> --body "Research doc merged in PR #<PR>. Follow-up issues: <list or 'none'>"`
 6. **Re-survey**: check for newly unblocked issues in the active milestone
 7. **Dispatch next batch** (up to 5 agents total active)
@@ -203,5 +218,6 @@ When the pipeline drains for the active milestone:
 - **Agents create their own follow-ups** — orchestrator reviews quality, doesn't recreate from scratch
 - **PRs must have full descriptions** — title, summary, key findings, follow-ups spawned
 - **No infinite loops** — stop when the milestone queue is empty
+- **Triage every follow-up before dispatch** — apply rubric immediately after each merge; close failing issues with `wont-research`; remove `triage` label from passing issues
 - **Post session report to Notion** when done
 - Report progress: log each completion/merge/follow-up creation as it happens


### PR DESCRIPTION
## Summary

Promotes the ad-hoc triage pass from the M1 research session into a permanent,
documented first-class gate. Every follow-up issue an agent creates is now scored
immediately after the parent PR merges, before it can re-enter the dispatch queue.

## Key Changes

- **CLAUDE.md**: two new labels (`triage`, `wont-research`) added to the label table;
  new "Research Issue Triage" section with 3-question rubric, label workflow, and
  anti-patterns that score 0 automatically
- **skills/research-worker.md**: agents required to add `triage` label to follow-up
  issues at creation; Step 3.4 expands to include full rubric-scoring procedure;
  triage added to the Constraints section

## Triage Rubric

Score ≥2/3 → keep. Score <2 → close with `wont-research`.

1. Changes a current-milestone implementation decision?
2. Genuinely new — not covered by an existing doc or issue?
3. Correctness or security risk if skipped?

## Follow-Up Issues Spawned

None — this is a system-level change with no research dependencies.

Closes #57