### PR TITLE
infra: research completion gate and follow-up milestone assignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,80 @@ gh issue edit <N> --add-label "wont-research"
 - Topics already answered in a merged research doc
 - Narrow edge cases that don't alter the core design
 
+## Research Completion Gate
+
+Research for a milestone is **done enough to begin implementation** when all remaining open
+research issues are non-blocking — i.e., none of them would require a significant rewrite of
+an implementation issue in the current milestone if answered later.
+
+### Blocking vs. non-blocking test
+
+A research issue is **blocking** if answering it would change the *design* (not just the
+*quality*) of a current-milestone implementation issue. Examples:
+- Blocking: "Does `--permission-prompt-tool` work in the current CLI?" — if no, the entire
+  security architecture in the runner must change.
+- Non-blocking: "What is the exact backoff curve for 429 retries?" — implementation proceeds
+  with a reasonable default; the answer refines but doesn't redesign.
+
+### Gate procedure
+
+Before each research-worker dispatch batch, the orchestrator checks:
+
+```
+For each open research issue in the active milestone:
+  Is there a specific current-milestone implementation issue that cannot be
+  designed without this answer?
+    YES → blocking, must dispatch before M_impl starts
+    NO  → non-blocking, migrate to the next research milestone
+```
+
+If **zero blocking issues remain**, declare research complete for this milestone:
+1. Migrate all remaining non-blocking open research issues to the next research milestone
+2. Post the session report (Step 5)
+3. STOP — do not create more research issues just to fill the queue
+
+### Milestone labels
+
+| Milestone | Purpose |
+|-----------|---------|
+| `M1: Foundation` | Research that must complete before M2 implementation begins |
+| `M2: Implementation` | Core v1 CLI implementation issues |
+| `M3: v2 Research` | Research for future versions — non-blocking for v1 |
+| `M4: v2 Implementation` | Future implementation (not yet scheduled) |
+
+## Follow-Up Milestone Assignment
+
+When a research agent (or the orchestrator) creates a new issue, it must choose the correct
+milestone — **do not default to the parent's milestone**.
+
+### Decision tree
+
+```
+Is this follow-up needed to design a v1 implementation issue?
+  YES → same milestone as the current research milestone (M1 if in M1 research)
+  NO  →
+    Is it needed for a v2 feature already scoped?
+      YES → M3: v2 Research
+      NO  → M3: v2 Research (default for anything non-blocking)
+```
+
+### Practical guidance for agents
+
+When writing the "Follow-Up Research Recommendations" section of a doc, tag each item:
+
+- `[BLOCKS_IMPL]` — must be researched before the current implementation milestone
+- `[V2_RESEARCH]` — useful but doesn't block v1; file under the next research milestone
+- `[WONT_RESEARCH]` — not worth a standalone doc; note inline
+
+Only create GitHub issues for `[BLOCKS_IMPL]` and `[V2_RESEARCH]` items.
+
+To find the correct milestone, inspect what exists and pick by purpose — do not hardcode names:
+```bash
+gh milestone list --repo <owner>/<repo>
+```
+`[BLOCKS_IMPL]` → current research milestone.
+`[V2_RESEARCH]` → the lowest-numbered research milestone beyond the current one.
+
 ## Issue Labels
 
 | Label | Purpose |

--- a/src/conductor/skills/research-worker.md
+++ b/src/conductor/skills/research-worker.md
@@ -135,7 +135,16 @@ Launch sub-agents in parallel using `Agent(isolation: "worktree")`.
 >    - Represents a genuinely new architectural/research question
 >    - Is NOT already covered by an existing issue (check: `gh issue list --state all --label research --limit 300 --json number,title`)
 >    - Would require a standalone research document to answer
->    - Use: `gh issue create --title "Research: <topic>" --label "research,triage" --milestone "<milestone name>" --body "..."`
+>    - Tag each recommendation in the doc's "Follow-Up Research Recommendations" section:
+>      - `[BLOCKS_IMPL]` — needed before the current implementation milestone can be designed
+>      - `[V2_RESEARCH]` — useful but doesn't block v1; belongs in a later research milestone
+>      - `[WONT_RESEARCH]` — not worth a standalone doc; note inline, don't file an issue
+>    - Only create GitHub issues for `[BLOCKS_IMPL]` and `[V2_RESEARCH]` items
+>    - To assign the milestone, inspect what milestones exist and their descriptions:
+>      `gh milestone list --repo <owner>/<repo>`
+>      Pick the lowest-numbered *research* milestone beyond the current one for `[V2_RESEARCH]` items.
+>      Use the current research milestone for `[BLOCKS_IMPL]` items.
+>    - Use: `gh issue create --title "Research: <topic>" --label "research,triage" --milestone "<resolved milestone name>" --body "..."`
 >    - Body MUST include: `## Spawned From`, `## Research Areas`, `## Deliverable`, `## Dependencies`
 >    - DO NOT create issues for: implementation tasks, data collection scripts, narrow empirical measurements, things already covered in existing docs
 >    - Add `triage` label to ALL follow-up issues — the orchestrator will score them; don't pre-filter, but be conservative
@@ -188,13 +197,29 @@ As **each agent completes** (do not wait for the entire batch):
 7. **Dispatch next batch** (up to 5 agents total active)
 8. **Continue** until active milestone queue is empty AND all agents complete
 
-### Step 4 — Completeness Check
+### Step 4 — Completeness Check and Research Gate
 
 When the pipeline drains for the active milestone:
 
-1. **Cross-cutting gap analysis**: Are there critical topics missing from the milestone that would block implementation?
-2. **Report any gaps** as new issues with the same milestone — do NOT auto-dispatch, leave for next session
-3. **Do NOT** generate follow-ups just to keep the pipeline going
+1. **Blocking gap analysis**: For each remaining open research issue in this milestone, ask:
+   *"Is there a specific implementation issue in the next milestone that cannot be designed
+   without this answer?"*
+   - YES → **blocking**: must dispatch before implementation begins; leave in current milestone
+   - NO → **non-blocking**: migrate to the next research milestone now:
+     ```bash
+     gh issue edit <N> --milestone "<next research milestone>"
+     ```
+
+2. **Ready-to-implement verdict**: If zero blocking issues remain after step 1:
+   - Declare: "Research milestone complete — ready to begin implementation."
+   - Do NOT create more research issues to fill the queue.
+   - The session report must include this verdict prominently.
+
+3. **Cross-cutting gap check**: Are there *blocking* topics not yet covered by any issue?
+   - If yes, file them as new issues in the current milestone — do NOT auto-dispatch.
+   - Apply the triage rubric and the `[BLOCKS_IMPL]` / `[V2_RESEARCH]` tags before filing.
+   - If no, leave it at that — a complete research milestone does not require every possible
+     question to be answered.
 
 ### Step 5 — Session Report
 


### PR DESCRIPTION
## Summary

Adds two missing pieces to the orchestration protocol: a gate that declares research
complete when no blocking issues remain, and milestone assignment rules so follow-up
issues land in the right phase rather than always inheriting the parent's milestone.

## Changes

**CLAUDE.md**
- New "Research Completion Gate" section: blocking vs non-blocking test, gate procedure,
  milestone table
- New "Follow-Up Milestone Assignment" section: decision tree, BLOCKS_IMPL / V2_RESEARCH /
  WONT_RESEARCH tags, context-driven milestone lookup via `gh milestone list`

**skills/research-worker.md**
- Agent prompt: agents now tag recommendations and call `gh milestone list` to assign
  the right milestone at creation time — no hardcoded names
- Step 4 rewritten: produces a "ready to implement" verdict, migrates non-blocking issues
  to next research milestone, stops creating issues when queue is genuinely empty

## Follow-Up Issues Spawned

None.

Closes #67