### PR TITLE
infra: pipeline stage tracking via GitHub issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,44 @@ uv add --dev <package>    # add dev dependency
 
 `main`
 
+## Pipeline Stage Tracking
+
+Each pipeline stage transition must be tracked as a GitHub issue so the current project
+phase is always visible from the issue tracker.
+
+### Issue format
+
+Title: `Run <worker> for <milestone or version>`
+
+Examples:
+- `Run research-worker for MVP Research`
+- `Run design-worker for MVP Research`
+- `Run impl-worker for MVP Implementation`
+- `Run plan-milestones for v2`
+
+### Lifecycle
+
+1. **Filed** — when the previous stage completes, the worker files the next stage's issue
+2. **`in-progress`** — added when the stage begins (same as any other issue)
+3. **Closed** — when the stage completes; the closing comment links to the Notion session report
+
+### Who files what
+
+| Stage completes | Files next issue |
+|----------------|-----------------|
+| `plan-milestones` | `Run research-worker for <milestone>` |
+| `research-worker` | `Run design-worker for <milestone>` |
+| `design-worker` | `Run impl-worker for <milestone>` |
+| `impl-worker` | `Run plan-milestones for <next version>` |
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "Run <worker> for <milestone>" \
+  --label "pipeline" \
+  --milestone "<relevant milestone>"
+```
+
 ## Research Issue Triage
 
 Every research issue — including follow-ups created by agents — **must pass the triage rubric
@@ -209,3 +247,4 @@ gh milestone list --repo <owner>/<repo>
 | `in-progress` | Currently being worked on (managed by orchestrator) |
 | `triage` | Follow-up issues pending triage decision (applied by research agents) |
 | `wont-research` | Closed by triage gate — below threshold for standalone research |
+| `pipeline` | Pipeline stage transition tracking issues |

--- a/src/composer/skills/design-worker.md
+++ b/src/composer/skills/design-worker.md
@@ -123,6 +123,11 @@ Print a summary:
 - Any research gaps that prevented full spec (flag as follow-up issues in the research milestone)
 - **Verdict**: "Ready for impl-worker — N issues filed, dependency graph complete."
 
+File the next pipeline stage issue:
+```bash
+gh issue create --title "Run impl-worker for <impl milestone>" --label "pipeline" --milestone "<impl milestone>"
+```
+
 Post a Notion report under "CC Autonomous Coding Sessions"
 (parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) with:
 - **Title**: `Design Session — {YYYY-MM-DD} — {repo name}`

--- a/src/composer/skills/impl-worker.md
+++ b/src/composer/skills/impl-worker.md
@@ -98,7 +98,14 @@ When the pipeline is fully drained (no active agents, no remaining dispatchable 
    - Issues failed/abandoned (with reasons)
    - Newly unblocked issues available for the next run
 
-2. **Post a Notion report** under "CC Autonomous Coding Sessions"
+2. **File the next pipeline stage issue** — kick off planning for the next version:
+   ```bash
+   gh issue create \
+     --title "Run plan-milestones for <next version>" \
+     --label "pipeline"
+   ```
+
+3. **Post a Notion report** under "CC Autonomous Coding Sessions"
    (parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) using
    `mcp__notion__API-post-page` with:
    - **Title**: `Session Report — {YYYY-MM-DD} — {repo name}`

--- a/src/composer/skills/plan-milestones.md
+++ b/src/composer/skills/plan-milestones.md
@@ -113,6 +113,11 @@ Print:
 - Explicit scope boundaries (what's in, what's out, what's next)
 - Suggested order of operations: which research issues to dispatch first
 
+File the next pipeline stage issue:
+```bash
+gh issue create --title "Run research-worker for <research milestone>" --label "pipeline" --milestone "<research milestone>"
+```
+
 Post a Notion report under "CC Autonomous Coding Sessions"
 (parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) with:
 - **Title**: `Milestone Plan — {YYYY-MM-DD} — {repo name} — {version name}`

--- a/src/composer/skills/research-worker.md
+++ b/src/composer/skills/research-worker.md
@@ -230,7 +230,12 @@ When the pipeline drains for the active milestone:
    - Remaining open research issues in active milestone
    - **Milestone completion status**: X of Y issues resolved
 
-2. **Post a Notion report** under "CC Autonomous Coding Sessions"
+2. **File the next pipeline stage issue** (only if research is declared complete):
+   ```bash
+   gh issue create --title "Run design-worker for <milestone>" --label "pipeline" --milestone "<milestone>"
+   ```
+
+3. **Post a Notion report** under "CC Autonomous Coding Sessions"
    (parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) using
    `mcp__notion__API-post-page` with:
    - **Title**: `Research Session — {YYYY-MM-DD} — {repo name}`


### PR DESCRIPTION
## Summary

Each worker now files the next stage's tracking issue when it completes,
keeping the issue tracker in sync with the actual pipeline phase at all times.

## Changes

- **CLAUDE.md**: new Pipeline Stage Tracking section — issue format, lifecycle
  (`filed → in-progress → closed`), responsibility table, `pipeline` label added
- **research-worker**: files `Run design-worker for <milestone>` when complete
- **design-worker**: files `Run impl-worker for <impl milestone>` when complete
- **plan-milestones**: files `Run research-worker for <research milestone>`
- **impl-worker**: files `Run plan-milestones for <next version>`

## Follow-Up Issues Spawned

None.

Closes #74