### PR TITLE
ci: fix review workflow github_token

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -20,6 +20,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           direct_prompt: |
             Review this pull request for the breadmin-composer Python CLI package.
 


### PR DESCRIPTION
Passes `github_token` to claude-code-action so it can post inline PR comments. Without it the action errors with OIDC/bad-credentials on every run.