### PR TITLE
infra: register all entry points and finalize pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,52 @@
 # breadmin-composer
 
-Headless Claude Code orchestrator CLI. Runs the full research → design → implementation
-pipeline as standalone CLI commands that invoke `claude -p` without a human at the terminal.
+breadmin-composer — headless Claude Code orchestrator for automated GitHub issue workstreams.
+
+Runs a four-stage research → design → implementation pipeline entirely from the terminal,
+invoking `claude -p` headlessly (no human at the terminal) to process GitHub issues,
+write research docs, translate findings into scoped implementation issues, and merge PRs.
+Each stage is driven by a dedicated CLI command that dispatches sub-agents in parallel and
+monitors CI until all work is complete.
+
+## Installation
+
+```bash
+uv sync
+```
+
+Requires Python 3.11+ and the following external tools on `$PATH`:
+
+- `claude` — Claude Code CLI (`claude -p` headless mode)
+- `gh` — GitHub CLI (authenticated)
+- `git`
 
 ## Worker Pipeline
 
 ```
-plan-milestones → research-worker → design-worker → impl-worker
+plan-issues → research-worker → design-worker → impl-worker
 ```
 
-Each product version flows through all four stages. See `CLAUDE.md` for the full protocol.
+Each product version flows through all four stages in order.
+No stage may be skipped. See `CLAUDE.md` for the full orchestration protocol.
 
-## Commands
+## Entry Points
 
-- `research-worker` — processes research issues for a milestone, writes `docs/research/` docs
-- `design-worker` — translates completed research into scoped implementation issues
-- `impl-worker` — claims impl issues, dispatches sub-agents, monitors CI, merges PRs
-- `conductor health` — preflight check (claude, gh, git, ANTHROPIC_API_KEY)
-- `conductor cost` — cost ledger summary from all sessions
+| Command | Description |
+|---------|-------------|
+| `research-worker` | Processes research issues for a milestone; writes docs to `docs/research/` |
+| `design-worker` | Translates completed research docs into scoped implementation issues |
+| `plan-issues` | Plans milestones and seeds research issues for the next version |
+| `impl-worker` | Claims impl issues, dispatches sub-agents, monitors CI, and merges PRs |
+| `composer` | Admin commands: `health` (preflight checks) and `cost` (cost ledger summary) |
 
-## Package structure
-
-```
-src/composer/
-├── cli.py          ← click commands: impl-worker, research-worker, design-worker, conductor
-├── config.py       ← Config pydantic model, env/flag resolution
-├── runner.py       ← claude -p subprocess invocation, stream-json capture
-├── session.py      ← session ID persistence and --resume logic
-├── logger.py       ← per-session JSONL logging + cost ledger
-├── health.py       ← preflight checks
-└── skills/
-    ├── impl-worker.md      ← bundled skill prompt
-    ├── research-worker.md  ← bundled skill prompt
-    ├── design-worker.md    ← bundled skill prompt
-    └── plan-milestones.md  ← bundled skill prompt
-```
-
-## Usage
+## Quick Usage
 
 ```bash
 # Preflight check
-conductor health
+composer health --repo OWNER/REPO
 
-# Plan milestones for a new version
-plan-milestones --repo OWNER/REPO  # interactive, run in a Claude Code session
+# Plan milestones and seed research issues for a new version
+plan-issues --repo OWNER/REPO
 
 # Research phase
 research-worker --repo OWNER/REPO --milestone "MVP Research"
@@ -55,21 +58,52 @@ design-worker --repo OWNER/REPO --research-milestone "MVP Research"
 impl-worker --repo OWNER/REPO --milestone "MVP Implementation"
 
 # Show cost ledger
-conductor cost
+composer cost
 ```
+
+Each worker accepts `--dry-run` (print without executing), `--model` (override Claude model),
+`--max-budget` (USD cap), `--max-turns`, and `--resume <run-id>` (resume a previous session).
+
+## Module Listing
+
+```
+src/composer/
+├── cli.py          ← Click entry points: research-worker, design-worker,
+│                     plan-issues, impl-worker, composer
+├── config.py       ← Config pydantic-settings model; env/flag resolution
+├── runner.py       ← claude -p subprocess invocation; stream-json capture
+├── session.py      ← Session ID persistence and --resume logic
+├── logger.py       ← Per-session JSONL logging and cost ledger
+├── health.py       ← Preflight checks (claude, gh, git, ANTHROPIC_API_KEY)
+└── skills/
+    ├── impl-worker.md      ← Bundled skill prompt for impl-worker
+    ├── research-worker.md  ← Bundled skill prompt for research-worker
+    ├── design-worker.md    ← Bundled skill prompt for design-worker
+    └── plan-milestones.md  ← Bundled skill prompt for plan-issues
+```
+
+## Key Types
+
+- `Config` (`config.py`) — validated configuration; loaded from environment + CLI flags
+- `Checkpoint` (`session.py`) — persisted session state for `--resume`
+- `RunResult` (`runner.py`) — result of a single `claude -p` invocation
+- `HealthReport` (`health.py`) — preflight check outcome with fatal/warn status
+- `UsageGovernor` (`cli.py`) — enforces concurrency limits and rate-limit backoff
 
 ## Configuration
 
-Copy `.env.example` to `.env` and fill in values, or set environment variables directly.
+Set environment variables or create a `.env` file:
 
-Key variables: `ANTHROPIC_API_KEY`, `CONDUCTOR_MODEL`, `CONDUCTOR_MAX_BUDGET`,
-`CONDUCTOR_MAX_TURNS`, `CONDUCTOR_DATA_DIR`.
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Required — Anthropic API key |
+| `COMPOSER_MODEL` | Claude model to use (default: `claude-opus-4-5`) |
+| `COMPOSER_MAX_BUDGET` | USD budget cap per session |
+| `COMPOSER_MAX_TURNS` | Max turns per `claude -p` invocation |
+| `COMPOSER_DATA_DIR` | Directory for checkpoints and logs (default: `~/.composer`) |
 
 ## Dependencies
 
-- Python 3.11+
-- `click` — CLI framework
-- `pydantic` — config validation
-- `claude` — Claude Code CLI (`claude -p` headless mode)
-- `gh` — GitHub CLI
-- `git`
+- `click>=8.1` — CLI framework
+- `pydantic>=2.0` — data validation
+- `pydantic-settings>=2.0` — environment-based configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ dependencies = [
 ]
 
 [project.scripts]
-impl-worker = "composer.cli:impl_worker"
+impl-worker     = "composer.cli:impl_worker"
 research-worker = "composer.cli:research_worker"
-design-worker = "composer.cli:design_worker"
-composer = "composer.cli:composer"
+design-worker   = "composer.cli:design_worker"
+plan-issues     = "composer.cli:plan_issues"
+composer        = "composer.cli:composer"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/composer"]


### PR DESCRIPTION
## Summary

- Added missing `plan-issues` entry point to `[project.scripts]` in `pyproject.toml` (all 5 entry points are now registered)
- Confirmed `pydantic-settings>=2.0` was already present as a runtime dependency — no change needed
- Verified project metadata: description accurate, version `0.1.0`, `requires-python = ">=3.11"`
- Updated `README.md` with: one-line description, 4-stage pipeline overview, installation (`uv sync`), 5-command entry points table with descriptions, quick usage examples for each worker, full module listing, key types exported, configuration table

## Smoke Test Results

All 5 entry points respond to `--help` correctly after `uv sync`:
- `research-worker --help` — OK
- `design-worker --help` — OK
- `plan-issues --help` — OK
- `impl-worker --help` — OK
- `composer --help` — OK (shows `health` and `cost` subcommands)

## Notes

Pre-existing lint errors were found in `src/composer/cli.py` (7 unused imports from a previous session's partial work). These are outside the allowed scope of this issue (`pyproject.toml`, `uv.lock`, `README.md`). A follow-up issue has been filed to clean them up.

Closes #136