### PR TITLE
feat: implement research-worker loop

### DIFF
--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -10,19 +10,36 @@ Entry points:
 
 from __future__ import annotations
 
+import json
 import os
+import re
+import subprocess
+import time
+from datetime import date
 from pathlib import Path
+from typing import Any
 
 import click
 
-from composer import health, logger, session
+from composer import health, logger, runner, session
 from composer.config import (
     Config,
     OrchestratorNestingError,
+    build_subprocess_env,
     load_config,
 )
 from composer.health import FatalHealthCheckError
 from composer.session import Checkpoint
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_RETRIES: int = 3
+MAX_PROMPT_CHARS: int = 16_000
+TRIAGE_LABEL: str = "triage"
+RESEARCH_LABEL: str = "research"
+BACKOFF_SLEEP_SECONDS: int = 30
 
 # ---------------------------------------------------------------------------
 # Startup sequence
@@ -256,6 +273,1018 @@ class UsageGovernor:
 
 
 # ---------------------------------------------------------------------------
+# Issue sanitization
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_issue_body(text: str, max_chars: int = MAX_PROMPT_CHARS) -> str:
+    """Strip shell metacharacters and truncate an issue body before embedding in a prompt.
+
+    Removes backticks and backslashes; rewrites ``$(`` as ``(`` to defuse command
+    substitution syntax. Truncates at *max_chars* with a marker suffix.
+
+    Args:
+        text:      Raw issue body text from the GitHub API.
+        max_chars: Maximum character count before truncation (default 16,000).
+
+    Returns:
+        Sanitized, possibly-truncated string safe to embed in a prompt.
+    """
+    text = re.sub(r"[`\\]", "", text)
+    text = re.sub(r"\$\(", "(", text)
+    if len(text) > max_chars:
+        text = text[:max_chars] + "\n\n[TRUNCATED — body exceeded 16,000 characters]"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# GitHub helper functions
+# ---------------------------------------------------------------------------
+
+
+def _gh(
+    args: list[str], *, repo: str | None = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    """Run a ``gh`` subcommand and return the CompletedProcess result.
+
+    Args:
+        args:  Arguments after ``gh`` (e.g. ``["issue", "list", "--json", "number"]``).
+        repo:  If provided, prepend ``["--repo", repo]`` before *args*.
+        check: If True, raise CalledProcessError on non-zero exit code.
+
+    Returns:
+        CompletedProcess with stdout/stderr captured as text.
+    """
+    cmd = ["gh"]
+    if repo:
+        cmd += ["--repo", repo]
+    cmd += args
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def _list_open_research_issues(repo: str, milestone: str) -> list[dict[str, Any]]:
+    """Return open, unassigned, non-in-progress research issues for *milestone*.
+
+    Calls ``gh issue list`` with JSON output and filters client-side:
+    - label contains ``research``
+    - milestone matches *milestone*
+    - no assignee
+    - label does NOT contain ``in-progress``
+
+    Args:
+        repo:      GitHub repository in ``owner/repo`` format.
+        milestone: Milestone name to scope the query.
+
+    Returns:
+        List of issue dicts with keys: number, title, body, labels, assignees.
+    """
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--label",
+            RESEARCH_LABEL,
+            "--milestone",
+            milestone,
+            "--json",
+            "number,title,body,labels,assignees,milestone",
+            "--limit",
+            "200",
+        ],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+
+    try:
+        issues: list[dict] = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    # Filter out assigned or in-progress issues
+    filtered = []
+    for issue in issues:
+        # Skip if anyone is assigned
+        if issue.get("assignees"):
+            continue
+        # Skip if in-progress label present
+        label_names = [lb.get("name", "") for lb in issue.get("labels", [])]
+        if "in-progress" in label_names:
+            continue
+        filtered.append(issue)
+
+    return filtered
+
+
+def _parse_dependencies(body: str) -> list[int]:
+    """Parse ``Depends on: #N`` references from an issue body.
+
+    Matches patterns like ``Depends on: #42`` or ``Depends on: #42, #43``.
+
+    Args:
+        body: Raw issue body text.
+
+    Returns:
+        List of referenced issue numbers as integers.
+    """
+    deps: list[int] = []
+    for match in re.finditer(r"[Dd]epends\s+on\s*:?\s*((?:#\d+(?:\s*,\s*)?)+)", body):
+        for num_match in re.finditer(r"#(\d+)", match.group(1)):
+            deps.append(int(num_match.group(1)))
+    return deps
+
+
+def _filter_unblocked(
+    issues: list[dict[str, Any]],
+    open_issue_numbers: set[int],
+) -> list[dict[str, Any]]:
+    """Remove issues whose dependencies are still open.
+
+    Args:
+        issues:             List of issue dicts (must include ``body`` and ``number``).
+        open_issue_numbers: Set of all currently open issue numbers in the milestone.
+
+    Returns:
+        Subset of *issues* whose ``Depends on`` references are all closed/absent.
+    """
+    unblocked = []
+    for issue in issues:
+        deps = _parse_dependencies(issue.get("body") or "")
+        if all(dep not in open_issue_numbers for dep in deps):
+            unblocked.append(issue)
+    return unblocked
+
+
+def _sort_issues(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort issues by lowest number (simple stable ordering, highest-impact-first heuristic).
+
+    In the absence of a full downstream-impact graph, issues are sorted by
+    number ascending (oldest first), which approximates the "highest impact first"
+    heuristic from the spec without requiring a graph traversal.
+
+    Args:
+        issues: List of issue dicts with at least a ``number`` key.
+
+    Returns:
+        Issues sorted by number ascending.
+    """
+    return sorted(issues, key=lambda i: i.get("number", 0))
+
+
+def _claim_issue(repo: str, issue_number: int) -> None:
+    """Add ``@me`` assignee and ``in-progress`` label to a GitHub issue.
+
+    Args:
+        repo:         Repository in ``owner/repo`` format.
+        issue_number: GitHub issue number.
+    """
+    _gh(
+        ["issue", "edit", str(issue_number), "--add-assignee", "@me", "--add-label", "in-progress"],
+        repo=repo,
+        check=False,
+    )
+
+
+def _unclaim_issue(repo: str, issue_number: int) -> None:
+    """Remove ``@me`` assignee and ``in-progress`` label from a GitHub issue.
+
+    Args:
+        repo:         Repository in ``owner/repo`` format.
+        issue_number: GitHub issue number.
+    """
+    _gh(
+        [
+            "issue",
+            "edit",
+            str(issue_number),
+            "--remove-assignee",
+            "@me",
+            "--remove-label",
+            "in-progress",
+        ],
+        repo=repo,
+        check=False,
+    )
+
+
+def _list_triage_issues(repo: str) -> list[dict[str, Any]]:
+    """Return all open issues labelled ``triage``.
+
+    Args:
+        repo: Repository in ``owner/repo`` format.
+
+    Returns:
+        List of issue dicts.
+    """
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--label",
+            TRIAGE_LABEL,
+            "--json",
+            "number,title,body,labels",
+            "--limit",
+            "200",
+        ],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def _close_issue_wont_research(repo: str, issue_number: int, score: int, reason: str) -> None:
+    """Close an issue as ``wont-research`` with a triage score comment.
+
+    Args:
+        repo:         Repository in ``owner/repo`` format.
+        issue_number: GitHub issue number.
+        score:        Triage score (0–3).
+        reason:       Short explanation for rejection.
+    """
+    comment = f"Closing: score {score}/3 on research triage rubric. {reason}"
+    _gh(
+        ["issue", "close", str(issue_number), "--reason", "not planned", "--comment", comment],
+        repo=repo,
+        check=False,
+    )
+    _gh(
+        [
+            "issue",
+            "edit",
+            str(issue_number),
+            "--add-label",
+            "wont-research",
+            "--remove-label",
+            TRIAGE_LABEL,
+        ],
+        repo=repo,
+        check=False,
+    )
+
+
+def _keep_triage_issue(repo: str, issue_number: int, milestone: str) -> None:
+    """Keep a triage issue: remove triage label and ensure milestone is set.
+
+    Args:
+        repo:         Repository in ``owner/repo`` format.
+        issue_number: GitHub issue number.
+        milestone:    Active milestone to assign if the issue has none.
+    """
+    _gh(
+        [
+            "issue",
+            "edit",
+            str(issue_number),
+            "--remove-label",
+            TRIAGE_LABEL,
+            "--milestone",
+            milestone,
+        ],
+        repo=repo,
+        check=False,
+    )
+
+
+def _find_next_research_milestone(repo: str, current_milestone: str) -> str | None:
+    """Find the next research milestone beyond *current_milestone*.
+
+    Queries ``gh milestone list`` and returns the title of the lowest-numbered
+    milestone whose title contains ``Research`` (case-insensitive) and whose
+    number is greater than the current milestone's number.
+
+    Args:
+        repo:               Repository in ``owner/repo`` format.
+        current_milestone:  Title of the current research milestone.
+
+    Returns:
+        Title of the next research milestone, or ``None`` if none exists.
+    """
+    result = _gh(
+        ["milestone", "list", "--json", "title,number,state", "--limit", "100"],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        milestones: list[dict] = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+    # Find the number of the current milestone
+    current_number: int | None = None
+    for ms in milestones:
+        if ms.get("title") == current_milestone:
+            current_number = ms.get("number")
+            break
+
+    if current_number is None:
+        return None
+
+    # Find the next open Research milestone
+    research_milestones = [
+        ms
+        for ms in milestones
+        if "research" in (ms.get("title") or "").lower()
+        and ms.get("state", "").lower() == "open"
+        and ms.get("number", 0) > current_number
+    ]
+    if not research_milestones:
+        return None
+
+    research_milestones.sort(key=lambda m: m.get("number", 0))
+    return research_milestones[0].get("title")
+
+
+def _find_impl_milestone(repo: str, research_milestone: str) -> str | None:
+    """Find the implementation milestone that corresponds to *research_milestone*.
+
+    Heuristic: look for the open milestone whose title contains ``Impl``
+    (case-insensitive) and shares a version token with *research_milestone*.
+
+    Args:
+        repo:               Repository in ``owner/repo`` format.
+        research_milestone: Title of the research milestone.
+
+    Returns:
+        Title of the matching implementation milestone, or ``None``.
+    """
+    result = _gh(
+        ["milestone", "list", "--json", "title,number,state", "--limit", "100"],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        milestones: list[dict] = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+    # Derive a version token from the research milestone title:
+    # e.g. "MVP Research" → "MVP", "v1.1 Research" → "v1.1"
+    version_token = research_milestone.lower().replace("research", "").strip()
+
+    for ms in milestones:
+        title_lower = (ms.get("title") or "").lower()
+        if "impl" in title_lower and version_token in title_lower:
+            return ms.get("title")
+
+    return None
+
+
+def _migrate_issue_to_milestone(repo: str, issue_number: int, milestone: str) -> None:
+    """Move an issue to a different milestone.
+
+    Args:
+        repo:         Repository in ``owner/repo`` format.
+        issue_number: GitHub issue number.
+        milestone:    Target milestone title.
+    """
+    _gh(
+        ["issue", "edit", str(issue_number), "--milestone", milestone],
+        repo=repo,
+        check=False,
+    )
+
+
+def _file_pipeline_issue(
+    repo: str,
+    next_worker: str,
+    milestone: str,
+    impl_milestone: str | None = None,
+) -> None:
+    """Create the next pipeline stage tracking issue.
+
+    Args:
+        repo:            Repository in ``owner/repo`` format.
+        next_worker:     Name of the next worker stage (e.g. ``"design-worker"``).
+        milestone:       Research milestone that just completed (used in the issue title).
+        impl_milestone:  Implementation milestone to assign the new issue to (optional).
+    """
+    title = f"Run {next_worker} for {milestone}"
+    cmd = [
+        "issue",
+        "create",
+        "--title",
+        title,
+        "--label",
+        "pipeline",
+        "--body",
+        f"Pipeline stage transition: {next_worker} is ready to run for {milestone}.",
+    ]
+    if impl_milestone:
+        cmd += ["--milestone", impl_milestone]
+    _gh(cmd, repo=repo, check=False)
+
+
+# ---------------------------------------------------------------------------
+# Triage rubric
+# ---------------------------------------------------------------------------
+
+
+def _score_triage_issue(
+    issue: dict[str, Any],
+    repo: str,
+    milestone: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    dry_run: bool = False,
+) -> int:
+    """Score a triage issue against the three-question rubric via a runner.run() call.
+
+    The scoring is done by dispatching a focused Claude call that reads the issue
+    body and answers three binary questions. The response is parsed to extract an
+    integer score 0–3.
+
+    Args:
+        issue:      Issue dict with ``number``, ``title``, and ``body``.
+        repo:       Repository in ``owner/repo`` format.
+        milestone:  Active milestone name (for context).
+        config:     Current Config instance.
+        checkpoint: Current Checkpoint instance.
+        dry_run:    If True, return a default score of 2 without calling runner.
+
+    Returns:
+        Integer score 0–3. Returns 2 on runner failure (conservative: keep).
+    """
+    if dry_run:
+        return 2
+
+    issue_number = issue.get("number", "?")
+    issue_title = issue.get("title", "")
+    issue_body = _sanitize_issue_body(issue.get("body") or "")
+
+    prompt = (
+        f"You are a research triage assistant. Score the following GitHub issue against the "
+        f"research triage rubric. Answer each question with YES or NO, then give a total score.\n\n"
+        f"Repository: {repo}\n"
+        f"Active Milestone: {milestone}\n\n"
+        f"## Issue #{issue_number}: {issue_title}\n\n"
+        f"{issue_body}\n\n"
+        f"## Rubric (score 1 point for each YES)\n\n"
+        f"1. **Decision impact**: Would NOT knowing this change an implementation decision "
+        f"in the current milestone ({milestone})?\n"
+        f"2. **Novelty**: Is this genuinely new, not already covered by an existing open or "
+        f"closed issue or merged doc in the repo?\n"
+        f"3. **Risk**: Would NOT knowing this create a correctness or security risk?\n\n"
+        f"Respond in this exact format:\n"
+        f"Q1: YES or NO\n"
+        f"Q2: YES or NO\n"
+        f"Q3: YES or NO\n"
+        f"SCORE: <integer 0-3>\n"
+    )
+
+    env = build_subprocess_env(config)
+    result = runner.run(
+        prompt=prompt,
+        allowed_tools=["Bash"],
+        env=env,
+        max_turns=5,
+    )
+
+    if result.is_error:
+        # Conservative: keep on runner failure
+        return 2
+
+    # Parse score from the result — look in all_events for assistant text
+    raw_event = result.raw_result_event or {}
+    result_text = raw_event.get("result", "") or ""
+
+    match = re.search(r"SCORE:\s*(\d)", result_text, re.IGNORECASE)
+    if match:
+        return min(3, max(0, int(match.group(1))))
+
+    # Fallback: count YES answers
+    yes_count = len(re.findall(r"Q\d+:\s*YES", result_text, re.IGNORECASE))
+    if yes_count > 0:
+        return min(3, yes_count)
+
+    # If parsing fails, default to keep (conservative)
+    return 2
+
+
+def _apply_triage_rubric(
+    repo: str,
+    milestone: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    dry_run: bool = False,
+) -> None:
+    """Fetch all open triage issues and apply the triage rubric to each.
+
+    Issues scoring < 2 are closed with ``wont-research``.
+    Issues scoring ≥ 2 have the triage label removed and stay open.
+
+    Args:
+        repo:       Repository in ``owner/repo`` format.
+        milestone:  Active milestone name (for scoring context).
+        config:     Current Config instance.
+        checkpoint: Current Checkpoint instance.
+        dry_run:    If True, print what would happen without modifying GitHub.
+    """
+    triage_issues = _list_triage_issues(repo)
+    for issue in triage_issues:
+        issue_number = issue["number"]
+        score = _score_triage_issue(
+            issue=issue,
+            repo=repo,
+            milestone=milestone,
+            config=config,
+            checkpoint=checkpoint,
+            dry_run=dry_run,
+        )
+        if score < 2:
+            if dry_run:
+                click.echo(
+                    f"  [dry-run] Would close #{issue_number} (score {score}/3) as wont-research"
+                )
+            else:
+                _close_issue_wont_research(
+                    repo=repo,
+                    issue_number=issue_number,
+                    score=score,
+                    reason="Below threshold for standalone research.",
+                )
+                logger.log_conductor_event(
+                    run_id=checkpoint.run_id,
+                    phase="triage",
+                    event_type="issue_claimed",
+                    payload={
+                        "issue_number": issue_number,
+                        "score": score,
+                        "action": "closed_wont_research",
+                    },
+                    log_dir=config.log_dir.expanduser(),
+                )
+        else:
+            if dry_run:
+                click.echo(f"  [dry-run] Would keep #{issue_number} (score {score}/3)")
+            else:
+                _keep_triage_issue(repo=repo, issue_number=issue_number, milestone=milestone)
+                logger.log_conductor_event(
+                    run_id=checkpoint.run_id,
+                    phase="triage",
+                    event_type="issue_claimed",
+                    payload={
+                        "issue_number": issue_number,
+                        "score": score,
+                        "action": "kept",
+                    },
+                    log_dir=config.log_dir.expanduser(),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Completion gate
+# ---------------------------------------------------------------------------
+
+
+def _classify_blocking_issues(
+    open_issues: list[dict[str, Any]],
+    repo: str,
+    milestone: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    dry_run: bool = False,
+) -> tuple[list[dict], list[dict]]:
+    """Classify remaining open research issues as blocking or non-blocking.
+
+    An issue is blocking if answering it would change the design of a
+    current-milestone implementation issue (not just improve its quality).
+
+    Classification heuristic:
+    1. If the issue body contains ``[BLOCKS_IMPL]`` tag → blocking.
+    2. Otherwise, call runner.run() to ask Claude to classify.
+
+    Args:
+        open_issues: List of open research issue dicts.
+        repo:        Repository in ``owner/repo`` format.
+        milestone:   Active research milestone name.
+        config:      Current Config instance.
+        checkpoint:  Current Checkpoint instance.
+        dry_run:     If True, treat all issues as non-blocking without calling runner.
+
+    Returns:
+        Tuple of (blocking_issues, non_blocking_issues).
+    """
+    if dry_run:
+        return [], open_issues
+
+    blocking: list[dict] = []
+    non_blocking: list[dict] = []
+
+    for issue in open_issues:
+        body = issue.get("body") or ""
+        if "[BLOCKS_IMPL]" in body:
+            blocking.append(issue)
+            continue
+
+        # Ask Claude to classify
+        issue_number = issue.get("number", "?")
+        issue_title = issue.get("title", "")
+        issue_body = _sanitize_issue_body(body)
+
+        prompt = (
+            f"You are a research classification assistant. Determine whether the following "
+            f"open research issue is BLOCKING or NON-BLOCKING for the current implementation "
+            f"milestone.\n\n"
+            f"A research issue is BLOCKING if answering it would change the *design* (not "
+            f"just the *quality*) of a current-milestone implementation issue. It is "
+            f"NON-BLOCKING if implementation can proceed with a reasonable default and the "
+            f"answer would only refine—not redesign—the implementation.\n\n"
+            f"Repository: {repo}\n"
+            f"Research Milestone: {milestone}\n\n"
+            f"## Issue #{issue_number}: {issue_title}\n\n"
+            f"{issue_body}\n\n"
+            f"Respond with exactly one word on the first line: BLOCKING or NON-BLOCKING\n"
+            f"Then a brief (1-2 sentence) reason.\n"
+        )
+
+        env = build_subprocess_env(config)
+        result = runner.run(
+            prompt=prompt,
+            allowed_tools=["Bash"],
+            env=env,
+            max_turns=5,
+        )
+
+        if result.is_error:
+            # Conservative: treat as non-blocking on runner failure
+            non_blocking.append(issue)
+            continue
+
+        raw_event = result.raw_result_event or {}
+        result_text = (raw_event.get("result") or "").strip().upper()
+
+        if result_text.startswith("BLOCKING"):
+            blocking.append(issue)
+        else:
+            non_blocking.append(issue)
+
+    return blocking, non_blocking
+
+
+# ---------------------------------------------------------------------------
+# Research worker implementation
+# ---------------------------------------------------------------------------
+
+
+def _run_research_worker(
+    repo: str,
+    milestone: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    dry_run: bool = False,
+) -> None:
+    """Main research-worker loop.
+
+    Processes one active research milestone to completion:
+    1. Per-iteration completion gate check.
+    2. Backoff check — sleep and retry if rate-limited.
+    3. Fetch next unblocked, unassigned research issue.
+    4. Sanitize issue body.
+    5. Build prompt via inject_skill.
+    6. Claim issue (add assignee + in-progress label).
+    7. Run runner.run().
+    8. Handle result (success → triage; rate-limited → unclaim + backoff; error → retry).
+
+    Args:
+        repo:       GitHub repository in ``owner/repo`` format.
+        milestone:  Active research milestone name.
+        config:     Validated Config instance.
+        checkpoint: Active Checkpoint instance.
+        dry_run:    If True, print invocations without executing.
+    """
+    gov = UsageGovernor(config, checkpoint)
+    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
+    retry_counts: dict[int, int] = {}
+
+    today = date.today().isoformat()
+
+    while True:
+        # ------------------------------------------------------------------
+        # STEP 1: Completion gate check (before each dispatch batch)
+        # ------------------------------------------------------------------
+        open_issues = _list_open_research_issues(repo, milestone)
+
+        if not open_issues:
+            # No open issues remain — run the completion gate
+            _run_completion_gate(
+                repo=repo,
+                milestone=milestone,
+                open_issues=[],
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=dry_run,
+            )
+            break
+
+        # Check if any open issues are blocking
+        blocking, non_blocking = _classify_blocking_issues(
+            open_issues=open_issues,
+            repo=repo,
+            milestone=milestone,
+            config=config,
+            checkpoint=checkpoint,
+            dry_run=dry_run,
+        )
+
+        if not blocking and not non_blocking:
+            # No issues at all
+            _run_completion_gate(
+                repo=repo,
+                milestone=milestone,
+                open_issues=[],
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=dry_run,
+            )
+            break
+
+        if not blocking:
+            # All remaining issues are non-blocking — research is complete
+            _run_completion_gate(
+                repo=repo,
+                milestone=milestone,
+                open_issues=non_blocking,
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=dry_run,
+            )
+            break
+
+        # ------------------------------------------------------------------
+        # STEP 2: Backoff check
+        # ------------------------------------------------------------------
+        if not gov.can_dispatch():
+            logger.log_conductor_event(
+                run_id=checkpoint.run_id,
+                phase="backoff",
+                event_type="backoff_enter",
+                payload={"reason": "rate_limit_or_concurrency"},
+                log_dir=config.log_dir.expanduser(),
+            )
+            time.sleep(BACKOFF_SLEEP_SECONDS)
+            continue
+
+        # ------------------------------------------------------------------
+        # STEP 3: Select next issue from blocking issues (unblocked subset)
+        # ------------------------------------------------------------------
+        open_issue_numbers = {i.get("number", 0) for i in open_issues}
+        unblocked = _filter_unblocked(blocking, open_issue_numbers)
+
+        if not unblocked:
+            # Blockers exist but all are blocked by dependencies — wait or sleep
+            if gov._active_agents == 0:
+                # Nothing is running and nothing is unblocked — unusual; sleep and retry
+                time.sleep(BACKOFF_SLEEP_SECONDS)
+                continue
+            else:
+                time.sleep(BACKOFF_SLEEP_SECONDS)
+                continue
+
+        ranked = _sort_issues(unblocked)
+        issue = ranked[0]
+        issue_number: int = issue["number"]
+
+        # ------------------------------------------------------------------
+        # STEP 4: Sanitize issue body
+        # ------------------------------------------------------------------
+        raw_body = issue.get("body") or ""
+        body = _sanitize_issue_body(raw_body)
+
+        # ------------------------------------------------------------------
+        # STEP 5: Build prompt
+        # ------------------------------------------------------------------
+        base_prompt = (
+            f"## Session Parameters\n"
+            f"- Repository: {repo}\n"
+            f"- Active Milestone: {milestone}\n"
+            f"- Issue: #{issue_number} — {issue.get('title', '')}\n"
+            f"- Session Date: {today}\n\n"
+            f"{body}"
+        )
+        prompt = inject_skill("research-worker", base_prompt)
+
+        if dry_run:
+            click.echo(
+                f"[dry-run] Would dispatch research agent for issue "
+                f"#{issue_number}: {issue.get('title', '')}"
+            )
+            click.echo(f"[dry-run] Prompt length: {len(prompt)} chars")
+            # Simulate completion gate with no real work
+            _run_completion_gate(
+                repo=repo,
+                milestone=milestone,
+                open_issues=[],
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=dry_run,
+            )
+            break
+
+        # ------------------------------------------------------------------
+        # STEP 6: Claim issue
+        # ------------------------------------------------------------------
+        _claim_issue(repo=repo, issue_number=issue_number)
+        session.record_dispatch(checkpoint, str(issue_number))
+        session.save(checkpoint, checkpoint_path)
+
+        logger.log_conductor_event(
+            run_id=checkpoint.run_id,
+            phase="claim",
+            event_type="issue_claimed",
+            payload={"issue_number": issue_number, "title": issue.get("title", "")},
+            log_dir=config.log_dir.expanduser(),
+        )
+
+        gov.record_dispatch(1)
+
+        # ------------------------------------------------------------------
+        # STEP 7: Run the research agent
+        # ------------------------------------------------------------------
+        env = build_subprocess_env(config)
+        result = runner.run(
+            prompt=prompt,
+            allowed_tools=[
+                "Bash",
+                "Read",
+                "Edit",
+                "Write",
+                "Glob",
+                "Grep",
+                "WebSearch",
+                "WebFetch",
+                "mcp__notion__API-post-page",
+            ],
+            env=env,
+            max_turns=100,
+        )
+
+        # ------------------------------------------------------------------
+        # STEP 8: Handle result
+        # ------------------------------------------------------------------
+        gov.record_completion(1)
+        gov.record_result(result)
+        session.save(checkpoint, checkpoint_path)
+
+        logger.log_conductor_event(
+            run_id=checkpoint.run_id,
+            phase="dispatch",
+            event_type="agent_completed",
+            payload={
+                "issue_number": issue_number,
+                "subtype": result.subtype,
+                "is_error": result.is_error,
+                "error_code": result.error_code,
+            },
+            log_dir=config.log_dir.expanduser(),
+        )
+
+        if result.subtype == "success" and not result.is_error:
+            # Success: apply triage rubric to any follow-up issues
+            _apply_triage_rubric(
+                repo=repo,
+                milestone=milestone,
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        elif result.error_code in ("rate_limit", "extra_usage_exhausted") or (
+            result.subtype == "error_max_budget_usd"
+        ):
+            # Rate-limited or budget exhausted: unclaim and back off
+            _unclaim_issue(repo=repo, issue_number=issue_number)
+            attempt = retry_counts.get(issue_number, 0)
+            gov.record_429(attempt)
+            retry_counts[issue_number] = attempt + 1
+
+            logger.log_conductor_event(
+                run_id=checkpoint.run_id,
+                phase="backoff",
+                event_type="backoff_enter",
+                payload={
+                    "issue_number": issue_number,
+                    "reason": result.error_code or result.subtype,
+                    "attempt": attempt,
+                },
+                log_dir=config.log_dir.expanduser(),
+            )
+            session.save(checkpoint, checkpoint_path)
+
+        elif result.is_error:
+            # Other error: increment retry count, unclaim for retry
+            current_retries = retry_counts.get(issue_number, 0) + 1
+            retry_counts[issue_number] = current_retries
+            _unclaim_issue(repo=repo, issue_number=issue_number)
+
+            if current_retries >= MAX_RETRIES:
+                logger.log_conductor_event(
+                    run_id=checkpoint.run_id,
+                    phase="dispatch",
+                    event_type="human_escalate",
+                    payload={
+                        "issue_number": issue_number,
+                        "reason": result.subtype or "unknown_error",
+                        "error_code": result.error_code,
+                        "retry_count": current_retries,
+                        "action_required": "manual investigation",
+                    },
+                    log_dir=config.log_dir.expanduser(),
+                )
+            # Issue returns to open state for retry in a future iteration
+
+        session.save(checkpoint, checkpoint_path)
+
+
+def _run_completion_gate(
+    repo: str,
+    milestone: str,
+    open_issues: list[dict[str, Any]],
+    config: Config,
+    checkpoint: Checkpoint,
+    dry_run: bool = False,
+) -> None:
+    """Declare research milestone complete and file the next pipeline issue.
+
+    Called when zero blocking issues remain. Migrates all remaining non-blocking
+    open issues to the next research milestone, logs stage_complete, and files
+    a ``Run design-worker for <milestone>`` pipeline issue.
+
+    Args:
+        repo:        Repository in ``owner/repo`` format.
+        milestone:   Completed research milestone name.
+        open_issues: Remaining non-blocking open issues to migrate.
+        config:      Current Config instance.
+        checkpoint:  Current Checkpoint instance.
+        dry_run:     If True, print actions without modifying GitHub.
+    """
+    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
+
+    # Migrate non-blocking issues to next research milestone
+    next_research_ms = _find_next_research_milestone(repo, milestone)
+    for issue in open_issues:
+        issue_number = issue["number"]
+        if dry_run:
+            click.echo(
+                f"[dry-run] Would migrate #{issue_number} to "
+                f"{next_research_ms or 'next research milestone'}"
+            )
+        else:
+            if next_research_ms:
+                _migrate_issue_to_milestone(
+                    repo=repo, issue_number=issue_number, milestone=next_research_ms
+                )
+
+    # Log stage_complete
+    logger.log_conductor_event(
+        run_id=checkpoint.run_id,
+        phase="complete",
+        event_type="stage_complete",
+        payload={
+            "milestone": milestone,
+            "non_blocking_migrated": len(open_issues),
+            "next_research_milestone": next_research_ms,
+        },
+        log_dir=config.log_dir.expanduser(),
+    )
+
+    # Find the implementation milestone for the pipeline issue
+    impl_milestone = _find_impl_milestone(repo, milestone)
+
+    # File pipeline issue: Run design-worker for <milestone>
+    if dry_run:
+        click.echo(f"[dry-run] Would file: 'Run design-worker for {milestone}'")
+    else:
+        _file_pipeline_issue(
+            repo=repo,
+            next_worker="design-worker",
+            milestone=milestone,
+            impl_milestone=impl_milestone,
+        )
+
+    session.save(checkpoint, checkpoint_path)
+
+    click.echo(
+        f"Research milestone '{milestone}' complete. "
+        f"Migrated {len(open_issues)} non-blocking issue(s). "
+        f"Filed 'Run design-worker for {milestone}' pipeline issue."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Entry points
 # ---------------------------------------------------------------------------
 
@@ -335,7 +1364,14 @@ def research_worker(
         stage="research",
         resume_run_id=resume,
     )
-    click.echo("Not yet implemented")
+
+    _run_research_worker(
+        repo=repo,
+        milestone=milestone,
+        config=_config,
+        checkpoint=_checkpoint,
+        dry_run=dry_run,
+    )
 
 
 @click.command("design-worker")

--- a/tests/unit/test_cli_research.py
+++ b/tests/unit/test_cli_research.py
@@ -1,0 +1,1266 @@
+"""Unit tests for the research-worker loop in src/composer/cli.py.
+
+Tests cover:
+- Issue selection filters (label, milestone, no assignee, not in-progress)
+- Triage rubric scoring (mock runner.run returning different scores)
+- Completion gate logic (zero blocking → stop)
+- Rate-limit requeue (record_429 called, issue unclaimed)
+- All subprocess and GitHub API calls are mocked
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from composer.cli import (
+    UsageGovernor,
+    _apply_triage_rubric,
+    _classify_blocking_issues,
+    _filter_unblocked,
+    _find_impl_milestone,
+    _find_next_research_milestone,
+    _list_open_research_issues,
+    _list_triage_issues,
+    _parse_dependencies,
+    _run_completion_gate,
+    _run_research_worker,
+    _sanitize_issue_body,
+    _score_triage_issue,
+    _sort_issues,
+)
+from composer.config import Config
+from composer.runner import RunResult
+from composer.session import Checkpoint
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_ENV = {
+    "ANTHROPIC_API_KEY": "sk-ant-test-key",
+    "GITHUB_TOKEN": "ghp-test-token",
+}
+
+
+def make_config(**overrides) -> Config:
+    """Return a minimal Config instance."""
+    with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+        config = Config(
+            anthropic_api_key=MINIMAL_ENV["ANTHROPIC_API_KEY"],
+            github_token=MINIMAL_ENV["GITHUB_TOKEN"],
+        )
+    for k, v in overrides.items():
+        object.__setattr__(config, k, v)
+    return config
+
+
+def make_checkpoint(**overrides) -> Checkpoint:
+    """Return a minimal Checkpoint instance."""
+    defaults = dict(
+        schema_version=1,
+        run_id="test-run-id",
+        session_id="",
+        repo="owner/repo",
+        default_branch="main",
+        milestone="MVP Research",
+        stage="research",
+        timestamp="2026-01-01T00:00:00+00:00",
+    )
+    defaults.update(overrides)
+    return Checkpoint(**defaults)
+
+
+def make_run_result(
+    *,
+    is_error: bool = False,
+    subtype: str | None = "success",
+    error_code: str | None = None,
+    result_text: str = "",
+) -> RunResult:
+    """Return a RunResult with the given classification."""
+    return RunResult(
+        is_error=is_error,
+        subtype=subtype,
+        error_code=error_code,
+        exit_code=1 if is_error else 0,
+        total_cost_usd=0.01 if not is_error else None,
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        raw_result_event={"result": result_text, "subtype": subtype} if result_text else None,
+        stderr="",
+        overage_detected=False,
+    )
+
+
+def make_issue(number: int, title: str = "Test issue", body: str = "", **extra) -> dict:
+    """Return a minimal GitHub issue dict."""
+    return {
+        "number": number,
+        "title": title,
+        "body": body,
+        "labels": [{"name": "research"}],
+        "assignees": [],
+        "milestone": {"title": "MVP Research"},
+        **extra,
+    }
+
+
+def make_gh_result(stdout: str = "", returncode: int = 0) -> MagicMock:
+    """Return a mock subprocess.CompletedProcess."""
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = ""
+    return result
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_issue_body
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeIssueBody:
+    def test_removes_backticks(self) -> None:
+        assert "`" not in _sanitize_issue_body("Use `code` here")
+
+    def test_removes_backslashes(self) -> None:
+        assert "\\" not in _sanitize_issue_body("path\\to\\file")
+
+    def test_replaces_dollar_paren(self) -> None:
+        result = _sanitize_issue_body("Run $(echo hello)")
+        assert "$(" not in result
+        assert "(echo hello)" in result
+
+    def test_truncates_at_max_chars(self) -> None:
+        long_text = "a" * 20_000
+        result = _sanitize_issue_body(long_text, max_chars=16_000)
+        assert len(result) > 16_000  # includes truncation marker
+        assert "TRUNCATED" in result
+        assert result.startswith("a" * 16_000)
+
+    def test_no_truncation_below_limit(self) -> None:
+        text = "short text"
+        result = _sanitize_issue_body(text)
+        assert result == text
+        assert "TRUNCATED" not in result
+
+    def test_empty_string(self) -> None:
+        assert _sanitize_issue_body("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_dependencies
+# ---------------------------------------------------------------------------
+
+
+class TestParseDependencies:
+    def test_parses_single_dependency(self) -> None:
+        body = "Depends on: #42"
+        assert _parse_dependencies(body) == [42]
+
+    def test_parses_multiple_dependencies(self) -> None:
+        body = "Depends on: #10, #20, #30"
+        assert _parse_dependencies(body) == [10, 20, 30]
+
+    def test_case_insensitive(self) -> None:
+        body = "depends on: #5"
+        assert _parse_dependencies(body) == [5]
+
+    def test_no_dependencies(self) -> None:
+        body = "This issue has no dependencies."
+        assert _parse_dependencies(body) == []
+
+    def test_ignores_non_dependency_issue_refs(self) -> None:
+        body = "See issue #99 for context. Depends on: #10"
+        result = _parse_dependencies(body)
+        assert 10 in result
+        assert 99 not in result
+
+
+# ---------------------------------------------------------------------------
+# _filter_unblocked
+# ---------------------------------------------------------------------------
+
+
+class TestFilterUnblocked:
+    def test_returns_all_when_no_dependencies(self) -> None:
+        issues = [make_issue(1), make_issue(2)]
+        result = _filter_unblocked(issues, open_issue_numbers={1, 2})
+        assert len(result) == 2
+
+    def test_excludes_issue_with_open_dependency(self) -> None:
+        issues = [
+            make_issue(1, body="Depends on: #2"),
+            make_issue(2),
+        ]
+        result = _filter_unblocked(issues, open_issue_numbers={1, 2})
+        # Issue 1 depends on 2 which is still open
+        assert len(result) == 1
+        assert result[0]["number"] == 2
+
+    def test_includes_issue_with_closed_dependency(self) -> None:
+        issues = [make_issue(1, body="Depends on: #5")]
+        # 5 is not in open_issue_numbers → dependency is closed
+        result = _filter_unblocked(issues, open_issue_numbers={1})
+        assert len(result) == 1
+
+    def test_empty_input(self) -> None:
+        assert _filter_unblocked([], open_issue_numbers=set()) == []
+
+
+# ---------------------------------------------------------------------------
+# _sort_issues
+# ---------------------------------------------------------------------------
+
+
+class TestSortIssues:
+    def test_sorted_by_number_ascending(self) -> None:
+        issues = [make_issue(30), make_issue(5), make_issue(10)]
+        result = _sort_issues(issues)
+        assert [i["number"] for i in result] == [5, 10, 30]
+
+    def test_stable_for_equal_numbers(self) -> None:
+        issues = [make_issue(1, title="A"), make_issue(1, title="B")]
+        result = _sort_issues(issues)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# _list_open_research_issues
+# ---------------------------------------------------------------------------
+
+
+class TestListOpenResearchIssues:
+    def test_filters_assigned_issues(self) -> None:
+        """Issues with assignees should be excluded."""
+        issues = [
+            {
+                "number": 1,
+                "title": "Open issue",
+                "body": "",
+                "labels": [{"name": "research"}],
+                "assignees": [],
+                "milestone": {"title": "MVP Research"},
+            },
+            {
+                "number": 2,
+                "title": "Assigned issue",
+                "body": "",
+                "labels": [{"name": "research"}],
+                "assignees": [{"login": "someone"}],
+                "milestone": {"title": "MVP Research"},
+            },
+        ]
+        gh_output = json.dumps(issues)
+
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(stdout=gh_output)):
+            result = _list_open_research_issues("owner/repo", "MVP Research")
+
+        assert len(result) == 1
+        assert result[0]["number"] == 1
+
+    def test_filters_in_progress_issues(self) -> None:
+        """Issues with in-progress label should be excluded."""
+        issues = [
+            {
+                "number": 3,
+                "title": "In-progress issue",
+                "body": "",
+                "labels": [{"name": "research"}, {"name": "in-progress"}],
+                "assignees": [],
+                "milestone": {"title": "MVP Research"},
+            },
+            {
+                "number": 4,
+                "title": "Available issue",
+                "body": "",
+                "labels": [{"name": "research"}],
+                "assignees": [],
+                "milestone": {"title": "MVP Research"},
+            },
+        ]
+        gh_output = json.dumps(issues)
+
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(stdout=gh_output)):
+            result = _list_open_research_issues("owner/repo", "MVP Research")
+
+        assert len(result) == 1
+        assert result[0]["number"] == 4
+
+    def test_returns_empty_on_gh_failure(self) -> None:
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(returncode=1)):
+            result = _list_open_research_issues("owner/repo", "MVP Research")
+        assert result == []
+
+    def test_returns_empty_on_invalid_json(self) -> None:
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(stdout="not json")):
+            result = _list_open_research_issues("owner/repo", "MVP Research")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _list_triage_issues
+# ---------------------------------------------------------------------------
+
+
+class TestListTriageIssues:
+    def test_returns_parsed_issues(self) -> None:
+        issues = [
+            {"number": 10, "title": "Follow-up A", "body": "...", "labels": [{"name": "triage"}]}
+        ]
+        gh_output = json.dumps(issues)
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(stdout=gh_output)):
+            result = _list_triage_issues("owner/repo")
+        assert len(result) == 1
+        assert result[0]["number"] == 10
+
+    def test_returns_empty_on_failure(self) -> None:
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(returncode=1)):
+            result = _list_triage_issues("owner/repo")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _score_triage_issue
+# ---------------------------------------------------------------------------
+
+
+class TestScoreTriageIssue:
+    def _make_score_result(self, score: int, q_answers: str = "") -> RunResult:
+        """Make a RunResult with SCORE: N in the result text."""
+        q_text = q_answers or f"Q1: YES\nQ2: YES\nQ3: NO\nSCORE: {score}\n"
+        return make_run_result(result_text=q_text)
+
+    def test_returns_score_from_runner_output(self) -> None:
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issue = make_issue(10, title="Follow-up", body="Does X affect Y?")
+
+        with patch("composer.cli.runner.run", return_value=self._make_score_result(2)):
+            with patch("composer.cli.build_subprocess_env", return_value={}):
+                score = _score_triage_issue(issue, "owner/repo", "MVP Research", config, checkpoint)
+
+        assert score == 2
+
+    def test_returns_3_for_all_yes(self) -> None:
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issue = make_issue(11, body="Critical")
+
+        result_text = "Q1: YES\nQ2: YES\nQ3: YES\nSCORE: 3\n"
+        with (
+            patch("composer.cli.runner.run", return_value=make_run_result(result_text=result_text)),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+        ):
+            score = _score_triage_issue(issue, "owner/repo", "MVP Research", config, checkpoint)
+
+        assert score == 3
+
+    def test_returns_0_for_all_no(self) -> None:
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issue = make_issue(12, body="Trivial")
+
+        result_text = "Q1: NO\nQ2: NO\nQ3: NO\nSCORE: 0\n"
+        with (
+            patch("composer.cli.runner.run", return_value=make_run_result(result_text=result_text)),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+        ):
+            score = _score_triage_issue(issue, "owner/repo", "MVP Research", config, checkpoint)
+
+        assert score == 0
+
+    def test_returns_2_on_runner_failure(self) -> None:
+        """Conservative: keep on runner failure (score=2)."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issue = make_issue(13, body="Some body")
+
+        err_result = make_run_result(is_error=True, subtype="error_during_execution")
+        with (
+            patch("composer.cli.runner.run", return_value=err_result),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+        ):
+            score = _score_triage_issue(issue, "owner/repo", "MVP Research", config, checkpoint)
+
+        assert score == 2
+
+    def test_returns_2_in_dry_run_mode(self) -> None:
+        """Dry run always returns 2 without calling runner."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issue = make_issue(14)
+
+        with patch("composer.cli.runner.run") as mock_run:
+            score = _score_triage_issue(
+                issue, "owner/repo", "MVP Research", config, checkpoint, dry_run=True
+            )
+
+        mock_run.assert_not_called()
+        assert score == 2
+
+
+# ---------------------------------------------------------------------------
+# _apply_triage_rubric
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTriageRubric:
+    def test_closes_low_score_issues(self) -> None:
+        """Issues scoring < 2 should be closed with wont-research."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        triage_issues = [make_issue(20, title="Low-value followup")]
+
+        with (
+            patch("composer.cli._list_triage_issues", return_value=triage_issues),
+            patch("composer.cli._score_triage_issue", return_value=1),
+            patch("composer.cli._close_issue_wont_research") as mock_close,
+            patch("composer.cli.logger.log_conductor_event"),
+        ):
+            _apply_triage_rubric("owner/repo", "MVP Research", config, checkpoint)
+
+        mock_close.assert_called_once_with(
+            repo="owner/repo",
+            issue_number=20,
+            score=1,
+            reason="Below threshold for standalone research.",
+        )
+
+    def test_keeps_high_score_issues(self) -> None:
+        """Issues scoring >= 2 should have triage label removed."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        triage_issues = [make_issue(21, title="High-value followup")]
+
+        with (
+            patch("composer.cli._list_triage_issues", return_value=triage_issues),
+            patch("composer.cli._score_triage_issue", return_value=3),
+            patch("composer.cli._keep_triage_issue") as mock_keep,
+            patch("composer.cli.logger.log_conductor_event"),
+        ):
+            _apply_triage_rubric("owner/repo", "MVP Research", config, checkpoint)
+
+        mock_keep.assert_called_once_with(
+            repo="owner/repo",
+            issue_number=21,
+            milestone="MVP Research",
+        )
+
+    def test_boundary_score_2_is_kept(self) -> None:
+        """Score of exactly 2 should keep the issue."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        triage_issues = [make_issue(22)]
+
+        with (
+            patch("composer.cli._list_triage_issues", return_value=triage_issues),
+            patch("composer.cli._score_triage_issue", return_value=2),
+            patch("composer.cli._keep_triage_issue") as mock_keep,
+            patch("composer.cli._close_issue_wont_research") as mock_close,
+            patch("composer.cli.logger.log_conductor_event"),
+        ):
+            _apply_triage_rubric("owner/repo", "MVP Research", config, checkpoint)
+
+        mock_keep.assert_called_once()
+        mock_close.assert_not_called()
+
+    def test_handles_empty_triage_list(self) -> None:
+        """Empty triage list should not call close or keep."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("composer.cli._list_triage_issues", return_value=[]),
+            patch("composer.cli._close_issue_wont_research") as mock_close,
+            patch("composer.cli._keep_triage_issue") as mock_keep,
+        ):
+            _apply_triage_rubric("owner/repo", "MVP Research", config, checkpoint)
+
+        mock_close.assert_not_called()
+        mock_keep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _classify_blocking_issues
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyBlockingIssues:
+    def test_blocks_impl_tag_marks_as_blocking(self) -> None:
+        """Issues with [BLOCKS_IMPL] in body are classified as blocking without runner call."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issues = [make_issue(1, body="[BLOCKS_IMPL] — critical design question")]
+
+        blocking, non_blocking = _classify_blocking_issues(
+            issues, "owner/repo", "MVP Research", config, checkpoint
+        )
+
+        assert len(blocking) == 1
+        assert len(non_blocking) == 0
+        assert blocking[0]["number"] == 1
+
+    def test_runner_blocking_response(self) -> None:
+        """Runner returning BLOCKING classifies the issue as blocking."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issues = [make_issue(2, body="Is X secure?")]
+
+        blocking_result = make_run_result(result_text="BLOCKING\nBecause it affects auth design.")
+        with (
+            patch("composer.cli.runner.run", return_value=blocking_result),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+        ):
+            blocking, non_blocking = _classify_blocking_issues(
+                issues, "owner/repo", "MVP Research", config, checkpoint
+            )
+
+        assert len(blocking) == 1
+        assert len(non_blocking) == 0
+
+    def test_runner_non_blocking_response(self) -> None:
+        """Runner returning NON-BLOCKING classifies the issue as non-blocking."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issues = [make_issue(3, body="What is the exact retry interval?")]
+
+        non_blocking_result = make_run_result(
+            result_text="NON-BLOCKING\nCan use reasonable default."
+        )
+        with (
+            patch("composer.cli.runner.run", return_value=non_blocking_result),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+        ):
+            blocking, non_blocking = _classify_blocking_issues(
+                issues, "owner/repo", "MVP Research", config, checkpoint
+            )
+
+        assert len(blocking) == 0
+        assert len(non_blocking) == 1
+
+    def test_runner_failure_defaults_to_non_blocking(self) -> None:
+        """Runner failure is treated conservatively as non-blocking."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issues = [make_issue(4, body="Some question")]
+
+        err_result = make_run_result(is_error=True, subtype="error_during_execution")
+        with (
+            patch("composer.cli.runner.run", return_value=err_result),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+        ):
+            blocking, non_blocking = _classify_blocking_issues(
+                issues, "owner/repo", "MVP Research", config, checkpoint
+            )
+
+        assert len(blocking) == 0
+        assert len(non_blocking) == 1
+
+    def test_dry_run_returns_all_non_blocking(self) -> None:
+        """In dry_run mode all issues are treated as non-blocking."""
+        config = make_config()
+        checkpoint = make_checkpoint()
+        issues = [make_issue(5, body="[BLOCKS_IMPL]"), make_issue(6, body="normal")]
+
+        with patch("composer.cli.runner.run") as mock_run:
+            blocking, non_blocking = _classify_blocking_issues(
+                issues, "owner/repo", "MVP Research", config, checkpoint, dry_run=True
+            )
+
+        mock_run.assert_not_called()
+        assert len(blocking) == 0
+        assert len(non_blocking) == 2
+
+
+# ---------------------------------------------------------------------------
+# _find_next_research_milestone
+# ---------------------------------------------------------------------------
+
+
+class TestFindNextResearchMilestone:
+    def test_finds_next_research_milestone(self) -> None:
+        milestones = [
+            {"title": "MVP Research", "number": 1, "state": "open"},
+            {"title": "v1.1 Research", "number": 3, "state": "open"},
+            {"title": "MVP Implementation", "number": 2, "state": "open"},
+        ]
+        gh_out = make_gh_result(stdout=json.dumps(milestones))
+        with patch("composer.cli.subprocess.run", return_value=gh_out):
+            result = _find_next_research_milestone("owner/repo", "MVP Research")
+        assert result == "v1.1 Research"
+
+    def test_returns_none_if_no_next_research_milestone(self) -> None:
+        milestones = [
+            {"title": "MVP Research", "number": 1, "state": "open"},
+        ]
+        gh_out = make_gh_result(stdout=json.dumps(milestones))
+        with patch("composer.cli.subprocess.run", return_value=gh_out):
+            result = _find_next_research_milestone("owner/repo", "MVP Research")
+        assert result is None
+
+    def test_returns_none_on_gh_failure(self) -> None:
+        with patch("composer.cli.subprocess.run", return_value=make_gh_result(returncode=1)):
+            result = _find_next_research_milestone("owner/repo", "MVP Research")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _find_impl_milestone
+# ---------------------------------------------------------------------------
+
+
+class TestFindImplMilestone:
+    def test_finds_matching_impl_milestone(self) -> None:
+        milestones = [
+            {"title": "MVP Research", "number": 1, "state": "open"},
+            {"title": "MVP Implementation", "number": 2, "state": "open"},
+        ]
+        gh_out = make_gh_result(stdout=json.dumps(milestones))
+        with patch("composer.cli.subprocess.run", return_value=gh_out):
+            result = _find_impl_milestone("owner/repo", "MVP Research")
+        assert result == "MVP Implementation"
+
+    def test_returns_none_if_no_matching_impl(self) -> None:
+        milestones = [
+            {"title": "MVP Research", "number": 1, "state": "open"},
+        ]
+        gh_out = make_gh_result(stdout=json.dumps(milestones))
+        with patch("composer.cli.subprocess.run", return_value=gh_out):
+            result = _find_impl_milestone("owner/repo", "MVP Research")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _run_completion_gate
+# ---------------------------------------------------------------------------
+
+
+class TestRunCompletionGate:
+    def test_migrates_non_blocking_issues(self, tmp_path: Path) -> None:
+        """Non-blocking issues are migrated to the next research milestone."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+        non_blocking = [make_issue(5), make_issue(6)]
+
+        with (
+            patch("composer.cli._find_next_research_milestone", return_value="v1.1 Research"),
+            patch("composer.cli._find_impl_milestone", return_value="MVP Implementation"),
+            patch("composer.cli._migrate_issue_to_milestone") as mock_migrate,
+            patch("composer.cli._file_pipeline_issue"),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_completion_gate(
+                repo="owner/repo",
+                milestone="MVP Research",
+                open_issues=non_blocking,
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        assert mock_migrate.call_count == 2
+        mock_migrate.assert_any_call(repo="owner/repo", issue_number=5, milestone="v1.1 Research")
+        mock_migrate.assert_any_call(repo="owner/repo", issue_number=6, milestone="v1.1 Research")
+
+    def test_files_pipeline_issue(self, tmp_path: Path) -> None:
+        """A 'Run design-worker for <milestone>' pipeline issue is created."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("composer.cli._find_next_research_milestone", return_value="v1.1 Research"),
+            patch("composer.cli._find_impl_milestone", return_value="MVP Implementation"),
+            patch("composer.cli._migrate_issue_to_milestone"),
+            patch("composer.cli._file_pipeline_issue") as mock_file,
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_completion_gate(
+                repo="owner/repo",
+                milestone="MVP Research",
+                open_issues=[],
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_file.assert_called_once_with(
+            repo="owner/repo",
+            next_worker="design-worker",
+            milestone="MVP Research",
+            impl_milestone="MVP Implementation",
+        )
+
+    def test_logs_stage_complete(self, tmp_path: Path) -> None:
+        """stage_complete event is logged."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("composer.cli._find_next_research_milestone", return_value=None),
+            patch("composer.cli._find_impl_milestone", return_value=None),
+            patch("composer.cli._migrate_issue_to_milestone"),
+            patch("composer.cli._file_pipeline_issue"),
+            patch("composer.cli.logger.log_conductor_event") as mock_log,
+            patch("composer.cli.session.save"),
+        ):
+            _run_completion_gate(
+                repo="owner/repo",
+                milestone="MVP Research",
+                open_issues=[],
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        logged_types = [c.kwargs.get("event_type") or c.args[2] for c in mock_log.call_args_list]
+        assert "stage_complete" in logged_types
+
+    def test_dry_run_does_not_call_gh(self, tmp_path: Path) -> None:
+        """In dry_run mode, no real GitHub calls are made."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("composer.cli._find_next_research_milestone", return_value="v1.1 Research"),
+            patch("composer.cli._find_impl_milestone", return_value=None),
+            patch("composer.cli._migrate_issue_to_milestone") as mock_migrate,
+            patch("composer.cli._file_pipeline_issue") as mock_file,
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+            patch("composer.cli.click.echo"),
+        ):
+            _run_completion_gate(
+                repo="owner/repo",
+                milestone="MVP Research",
+                open_issues=[make_issue(99)],
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=True,
+            )
+
+        mock_migrate.assert_not_called()
+        mock_file.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _run_research_worker — completion gate (zero blocking → stop)
+# ---------------------------------------------------------------------------
+
+
+class TestRunResearchWorkerCompletionGate:
+    def test_stops_when_no_open_issues(self, tmp_path: Path) -> None:
+        """Worker exits immediately when there are no open research issues."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("composer.cli._list_open_research_issues", return_value=[]),
+            patch("composer.cli._run_completion_gate") as mock_gate,
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_gate.assert_called_once()
+
+    def test_stops_when_zero_blocking_issues(self, tmp_path: Path) -> None:
+        """Worker exits when all remaining open issues are non-blocking."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        open_issues = [make_issue(10, body="Non-blocking research")]
+
+        with (
+            patch("composer.cli._list_open_research_issues", return_value=open_issues),
+            patch("composer.cli._classify_blocking_issues", return_value=([], open_issues)),
+            patch("composer.cli._run_completion_gate") as mock_gate,
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_gate.assert_called_once_with(
+            repo="owner/repo",
+            milestone="MVP Research",
+            open_issues=open_issues,
+            config=config,
+            checkpoint=checkpoint,
+            dry_run=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _run_research_worker — issue selection filters
+# ---------------------------------------------------------------------------
+
+
+class TestRunResearchWorkerIssueSelection:
+    def test_dispatches_unblocked_issue(self, tmp_path: Path) -> None:
+        """An available blocking issue should be dispatched."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        success_result = make_run_result(subtype="success")
+
+        calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            # First call: return open issue; second call (after dispatch): return empty
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return [blocking_issue]
+            return []
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            if open_issues:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue") as mock_claim,
+            patch("composer.cli.runner.run", return_value=success_result),
+            patch("composer.cli._apply_triage_rubric"),
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_claim.assert_called_once_with(repo="owner/repo", issue_number=1)
+
+    def test_applies_triage_after_success(self, tmp_path: Path) -> None:
+        """After a successful run, triage rubric should be applied."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        success_result = make_run_result(subtype="success")
+
+        calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                return [blocking_issue]
+            return []
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            if open_issues:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue"),
+            patch("composer.cli.runner.run", return_value=success_result),
+            patch("composer.cli._apply_triage_rubric") as mock_triage,
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_triage.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_research_worker — rate-limit requeue
+# ---------------------------------------------------------------------------
+
+
+class TestRunResearchWorkerRateLimit:
+    def test_unclaims_issue_on_rate_limit(self, tmp_path: Path) -> None:
+        """On rate-limited result, issue should be unclaimed and backoff set."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        rate_limited_result = make_run_result(
+            is_error=True,
+            subtype="error_during_execution",
+            error_code="rate_limit",
+        )
+
+        calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            calls["count"] += 1
+            if calls["count"] <= 2:
+                return [blocking_issue]
+            return []
+
+        classify_calls = {"count": 0}
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            classify_calls["count"] += 1
+            if classify_calls["count"] <= 2:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue"),
+            patch("composer.cli._unclaim_issue") as mock_unclaim,
+            patch("composer.cli.runner.run", return_value=rate_limited_result),
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+            patch("composer.cli.time.sleep"),  # skip actual sleep
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        # Issue should have been unclaimed after the rate-limited result
+        mock_unclaim.assert_called_with(repo="owner/repo", issue_number=1)
+
+    def test_record_429_called_on_rate_limit(self, tmp_path: Path) -> None:
+        """UsageGovernor.record_429 must be called when rate-limited."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        rate_limited_result = make_run_result(
+            is_error=True,
+            subtype="error_during_execution",
+            error_code="rate_limit",
+        )
+
+        calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            calls["count"] += 1
+            # Return issue twice so we can observe one rate-limit cycle, then stop
+            if calls["count"] <= 2:
+                return [blocking_issue]
+            return []
+
+        classify_calls = {"count": 0}
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            classify_calls["count"] += 1
+            if classify_calls["count"] <= 2:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue"),
+            patch("composer.cli._unclaim_issue"),
+            patch("composer.cli.runner.run", return_value=rate_limited_result),
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+            patch("composer.cli.time.sleep"),
+            patch.object(UsageGovernor, "record_429") as mock_429,
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_429.assert_called()
+
+    def test_record_429_also_called_on_budget_exhausted(self, tmp_path: Path) -> None:
+        """record_429 is called on error_max_budget_usd too."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        budget_result = make_run_result(
+            is_error=True,
+            subtype="error_max_budget_usd",
+            error_code=None,
+        )
+
+        calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            calls["count"] += 1
+            if calls["count"] <= 2:
+                return [blocking_issue]
+            return []
+
+        classify_calls = {"count": 0}
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            classify_calls["count"] += 1
+            if classify_calls["count"] <= 2:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue"),
+            patch("composer.cli._unclaim_issue"),
+            patch("composer.cli.runner.run", return_value=budget_result),
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+            patch("composer.cli.time.sleep"),
+        ):
+            with patch.object(UsageGovernor, "record_429") as mock_429:
+                _run_research_worker(
+                    repo="owner/repo",
+                    milestone="MVP Research",
+                    config=config,
+                    checkpoint=checkpoint,
+                )
+
+        mock_429.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _run_research_worker — error retry and escalation
+# ---------------------------------------------------------------------------
+
+
+class TestRunResearchWorkerErrorHandling:
+    def test_escalates_after_max_retries(self, tmp_path: Path) -> None:
+        """After MAX_RETRIES failures, a human_escalate event is logged."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        error_result = make_run_result(is_error=True, subtype="error_during_execution")
+
+        dispatch_calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            # Return the issue enough times to exhaust retries, then stop
+            dispatch_calls["count"] += 1
+            if dispatch_calls["count"] <= 4:
+                return [blocking_issue]
+            return []
+
+        classify_calls = {"count": 0}
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            classify_calls["count"] += 1
+            if classify_calls["count"] <= 4:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        logged_events: list[str] = []
+
+        def capture_event(**kwargs):
+            logged_events.append(kwargs.get("event_type", ""))
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue"),
+            patch("composer.cli._unclaim_issue"),
+            patch("composer.cli.runner.run", return_value=error_result),
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event", side_effect=capture_event),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        assert "human_escalate" in logged_events
+
+    def test_unclaims_issue_on_error(self, tmp_path: Path) -> None:
+        """On any error, the issue should be unclaimed for retry."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        error_result = make_run_result(is_error=True, subtype="error_during_execution")
+
+        calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone):
+            calls["count"] += 1
+            if calls["count"] <= 2:
+                return [blocking_issue]
+            return []
+
+        classify_calls = {"count": 0}
+
+        def classify_side_effect(open_issues, repo, milestone, config, checkpoint, dry_run=False):
+            classify_calls["count"] += 1
+            if classify_calls["count"] <= 2:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        with (
+            patch("composer.cli._list_open_research_issues", side_effect=open_issues_side_effect),
+            patch("composer.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli._claim_issue"),
+            patch("composer.cli._unclaim_issue") as mock_unclaim,
+            patch("composer.cli.runner.run", return_value=error_result),
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.build_subprocess_env", return_value={}),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.record_dispatch"),
+            patch("composer.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        mock_unclaim.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _run_research_worker — dry_run mode
+# ---------------------------------------------------------------------------
+
+
+class TestRunResearchWorkerDryRun:
+    def test_dry_run_does_not_call_runner(self, tmp_path: Path) -> None:
+        """In dry_run mode, runner.run should never be called."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+
+        with (
+            patch("composer.cli._list_open_research_issues", return_value=[blocking_issue]),
+            patch("composer.cli._classify_blocking_issues", return_value=([blocking_issue], [])),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli.runner.run") as mock_run,
+            patch("composer.cli._run_completion_gate"),
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+            patch("composer.cli.click.echo"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=True,
+            )
+
+        mock_run.assert_not_called()
+
+    def test_dry_run_calls_completion_gate(self, tmp_path: Path) -> None:
+        """In dry_run mode, completion gate should still be called."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+
+        with (
+            patch("composer.cli._list_open_research_issues", return_value=[blocking_issue]),
+            patch("composer.cli._classify_blocking_issues", return_value=([blocking_issue], [])),
+            patch("composer.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("composer.cli._sort_issues", return_value=[blocking_issue]),
+            patch("composer.cli.runner.run"),
+            patch("composer.cli._run_completion_gate") as mock_gate,
+            patch("composer.cli.logger.log_conductor_event"),
+            patch("composer.cli.session.save"),
+            patch("composer.cli.click.echo"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+                dry_run=True,
+            )
+
+        mock_gate.assert_called_once()


### PR DESCRIPTION
## Summary

- Replaces the `click.echo("Not yet implemented")` stub in `research_worker()` with a full production loop
- Implements the completion gate (blocking/non-blocking classification via Claude), per-issue dispatch, triage rubric, rate-limit backoff, and pipeline issue filing
- Adds 57 unit tests covering all acceptance criteria from issue #132

## What was implemented

**`_run_research_worker()`** — main loop:
- Per-iteration completion gate check: calls `_classify_blocking_issues()` (via `runner.run()`) before each dispatch batch; if zero blocking remain, migrates non-blocking issues to the next research milestone, logs `stage_complete`, files `Run design-worker for <milestone>` pipeline issue, and exits
- Backoff check via `UsageGovernor.can_dispatch()` — sleeps and retries if rate-limited or at concurrency limit
- Issue selection: `_list_open_research_issues()` → unassigned, non-in-progress, research-labelled, milestone-scoped; `_filter_unblocked()` removes dependency-blocked issues; `_sort_issues()` sorts by number ascending
- Issue claiming: `gh issue edit --add-assignee @me --add-label in-progress`
- Prompt assembly: `_sanitize_issue_body()` strips shell metacharacters; `inject_skill("research-worker", ...)` prepends the skill file
- Runner dispatch: `runner.run()` with full allowed-tools list and `max_turns=100`
- Result handling: success → `_apply_triage_rubric()`; rate-limited → unclaim + `record_429()`; budget-exhausted → same; error → unclaim + retry up to `MAX_RETRIES` → `human_escalate` event

**`_apply_triage_rubric()`** — scores each open `triage`-labelled issue via `runner.run()` (3-question rubric); score ≥ 2 → keep (remove triage label, ensure milestone); score < 2 → close with `wont-research`

**`_classify_blocking_issues()`** — checks `[BLOCKS_IMPL]` tag first, then calls `runner.run()` to classify remaining issues as BLOCKING or NON-BLOCKING

**Helper functions added**: `_sanitize_issue_body`, `_parse_dependencies`, `_filter_unblocked`, `_sort_issues`, `_list_open_research_issues`, `_list_triage_issues`, `_claim_issue`, `_unclaim_issue`, `_gh`, `_close_issue_wont_research`, `_keep_triage_issue`, `_find_next_research_milestone`, `_find_impl_milestone`, `_migrate_issue_to_milestone`, `_file_pipeline_issue`, `_run_completion_gate`

## Test plan

- [x] `uv run pytest tests/unit/test_cli_research.py -v` — 57 tests pass
- [x] `uv run pytest` — 300 tests pass (no regressions)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean

Closes #132