### PR TITLE
feat: implement composer admin commands (health, cost)

### DIFF
--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -11,6 +11,7 @@ Entry points:
 from __future__ import annotations
 
 import concurrent.futures
+import dataclasses
 import json
 import os
 import re
@@ -2584,25 +2585,143 @@ def health_cmd(repo: str | None, as_json: bool) -> None:
     chk = session.load(checkpoint_path)
     report = health.check_all(config, chk)
     if as_json:
-        import dataclasses
-        import json as _json
-
-        click.echo(_json.dumps(dataclasses.asdict(report), indent=2))
+        click.echo(json.dumps(dataclasses.asdict(report), indent=2))
     else:
         click.echo(health.format_report(report))
     raise SystemExit(0 if not report.fatal else 1)
 
 
 @composer.command("cost")
-def cost() -> None:
+@click.option("--repo", default=None, help="Filter to a specific repo (OWNER/REPO)")
+@click.option("--stage", default=None, help="Filter to a specific stage")
+def cost(repo: str | None, stage: str | None) -> None:
     """Show cost ledger summary."""
     config = load_config()
-    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
-    _chk = session.load(checkpoint_path)
-    _config, _checkpoint = startup_sequence(
-        config=config,
-        checkpoint_path=checkpoint_path,
-        milestone="",
-        stage="cost",
+    entries = logger.read_cost_ledger(
+        config.log_dir.expanduser(),
+        repo=repo,
+        stage=stage,
     )
-    click.echo("Not yet implemented")
+
+    if not entries:
+        click.echo("No cost entries found.")
+        return
+
+    # Group by repo -> stage: {repo: {stage: {sessions, input, output, cost}}}
+    grouped: dict[str, dict[str, dict[str, Any]]] = {}
+    for entry in entries:
+        entry_repo: str = entry.get("repo") or "(unknown)"
+        entry_stage: str = entry.get("stage") or "(unknown)"
+        if entry_repo not in grouped:
+            grouped[entry_repo] = {}
+        if entry_stage not in grouped[entry_repo]:
+            grouped[entry_repo][entry_stage] = {
+                "sessions": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cost_usd": 0.0,
+            }
+        agg = grouped[entry_repo][entry_stage]
+        agg["sessions"] += 1
+        agg["input_tokens"] += entry.get("input_tokens", 0) or 0
+        agg["output_tokens"] += entry.get("output_tokens", 0) or 0
+        cost_val = entry.get("total_cost_usd")
+        agg["cost_usd"] += cost_val if cost_val is not None else 0.0
+
+    # Column widths
+    col_stage = 16
+    col_sessions = 8
+    col_input = 15
+    col_output = 13
+    col_cost = 15
+    sep = (
+        "+"
+        + "-" * (col_stage + 2)
+        + "+"
+        + "-" * (col_sessions + 2)
+        + "+"
+        + "-" * (col_input + 2)
+        + "+"
+        + "-" * (col_output + 2)
+        + "+"
+        + "-" * (col_cost + 2)
+        + "+"
+    )
+    header = (
+        "| "
+        + "Stage".ljust(col_stage)
+        + " | "
+        + "Sessions".rjust(col_sessions)
+        + " | "
+        + "Input Tokens".rjust(col_input)
+        + " | "
+        + "Output Tokens".rjust(col_output)
+        + " | "
+        + "Est. Cost (USD)".rjust(col_cost)
+        + " |"
+    )
+
+    grand_sessions = 0
+    grand_input = 0
+    grand_output = 0
+    grand_cost = 0.0
+
+    for entry_repo, stages in sorted(grouped.items()):
+        click.echo(f"\nRepo: {entry_repo}")
+        click.echo(sep)
+        click.echo(header)
+        click.echo(sep)
+
+        repo_sessions = 0
+        repo_input = 0
+        repo_output = 0
+        repo_cost = 0.0
+
+        for entry_stage, agg in sorted(stages.items()):
+            s = agg["sessions"]
+            i = agg["input_tokens"]
+            o = agg["output_tokens"]
+            c = agg["cost_usd"]
+            repo_sessions += s
+            repo_input += i
+            repo_output += o
+            repo_cost += c
+            row = (
+                "| "
+                + entry_stage.ljust(col_stage)
+                + " | "
+                + f"{s:,}".rjust(col_sessions)
+                + " | "
+                + f"{i:,}".rjust(col_input)
+                + " | "
+                + f"{o:,}".rjust(col_output)
+                + " | "
+                + f"${c:,.2f}".rjust(col_cost)
+                + " |"
+            )
+            click.echo(row)
+
+        click.echo(sep)
+        total_row = (
+            "| "
+            + "TOTAL".ljust(col_stage)
+            + " | "
+            + f"{repo_sessions:,}".rjust(col_sessions)
+            + " | "
+            + f"{repo_input:,}".rjust(col_input)
+            + " | "
+            + f"{repo_output:,}".rjust(col_output)
+            + " | "
+            + f"${repo_cost:,.2f}".rjust(col_cost)
+            + " |"
+        )
+        click.echo(total_row)
+        click.echo(sep)
+
+        grand_sessions += repo_sessions
+        grand_input += repo_input
+        grand_output += repo_output
+        grand_cost += repo_cost
+
+    num_repos = len(grouped)
+    click.echo(f"\nGrand total across {num_repos} repo(s): ${grand_cost:,.2f}")

--- a/tests/unit/test_cli_admin.py
+++ b/tests/unit/test_cli_admin.py
@@ -1,0 +1,424 @@
+"""Unit tests for composer admin commands: health and cost."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from composer.cli import cost, health_cmd
+from composer.health import CheckResult, HealthReport
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_ENV = {
+    "ANTHROPIC_API_KEY": "sk-ant-test-key",
+    "GITHUB_TOKEN": "ghp-test-token",
+}
+
+
+def _make_pass_report() -> HealthReport:
+    """Return a HealthReport with all checks passing."""
+    return HealthReport(
+        checks=[
+            CheckResult(name="Check A", status="pass", message="All good."),
+            CheckResult(name="Check B", status="pass", message="Also good."),
+        ],
+        overall="pass",
+        fatal=False,
+    )
+
+
+def _make_warn_report() -> HealthReport:
+    """Return a HealthReport with a warning but no fatal."""
+    return HealthReport(
+        checks=[
+            CheckResult(name="Check A", status="pass", message="Good."),
+            CheckResult(
+                name="Check B",
+                status="warn",
+                message="Something is off.",
+                remediation="Fix it.",
+            ),
+        ],
+        overall="warn",
+        fatal=False,
+    )
+
+
+def _make_fatal_report() -> HealthReport:
+    """Return a HealthReport with a fatal failure."""
+    return HealthReport(
+        checks=[
+            CheckResult(
+                name="Check A",
+                status="fail",
+                message="Critical failure.",
+                remediation="Do something.",
+            ),
+        ],
+        overall="fail",
+        fatal=True,
+    )
+
+
+def _make_cost_entry(
+    repo: str = "owner/repo",
+    stage: str = "research",
+    input_tokens: int = 1000,
+    output_tokens: int = 200,
+    total_cost_usd: float | None = 1.50,
+) -> dict[str, Any]:
+    return {
+        "timestamp": "2026-01-01T00:00:00+00:00",
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "repo": repo,
+        "stage": stage,
+        "issue_number": None,
+        "model": "claude-sonnet-4-6",
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "num_turns": 5,
+        "duration_ms": 1000,
+        "is_error": False,
+        "error_subtype": None,
+        "total_cost_usd": total_cost_usd,
+        "auth_mode": "subscription",
+        "web_search_requests": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# health_cmd tests
+# ---------------------------------------------------------------------------
+
+
+class TestHealthCmd:
+    def test_exits_0_on_pass_report(self) -> None:
+        """health_cmd exits 0 when the report has no fatal."""
+        runner = CliRunner()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.session.load", return_value=None),
+            patch("composer.cli.health.check_all", return_value=_make_pass_report()),
+            patch("composer.cli.health.format_report", return_value="All good."),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.checkpoint_dir.expanduser.return_value = Path("/tmp/checkpoints")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(health_cmd, [])
+
+        assert result.exit_code == 0
+
+    def test_exits_0_on_warn_report(self) -> None:
+        """health_cmd exits 0 when the report has warnings but no fatal."""
+        runner = CliRunner()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.session.load", return_value=None),
+            patch("composer.cli.health.check_all", return_value=_make_warn_report()),
+            patch("composer.cli.health.format_report", return_value="Warnings present."),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.checkpoint_dir.expanduser.return_value = Path("/tmp/checkpoints")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(health_cmd, [])
+
+        assert result.exit_code == 0
+
+    def test_exits_1_on_fatal_report(self) -> None:
+        """health_cmd exits 1 when the report has a fatal check."""
+        runner = CliRunner()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.session.load", return_value=None),
+            patch("composer.cli.health.check_all", return_value=_make_fatal_report()),
+            patch("composer.cli.health.format_report", return_value="Fatal failure."),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.checkpoint_dir.expanduser.return_value = Path("/tmp/checkpoints")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(health_cmd, [])
+
+        assert result.exit_code == 1
+
+    def test_json_flag_outputs_valid_json(self) -> None:
+        """health_cmd --json outputs valid JSON containing the report fields."""
+        runner = CliRunner()
+        report = _make_pass_report()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.session.load", return_value=None),
+            patch("composer.cli.health.check_all", return_value=report),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.checkpoint_dir.expanduser.return_value = Path("/tmp/checkpoints")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(health_cmd, ["--json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "checks" in parsed
+        assert "overall" in parsed
+        assert "fatal" in parsed
+        assert parsed["overall"] == "pass"
+        assert parsed["fatal"] is False
+        assert len(parsed["checks"]) == 2
+
+    def test_json_flag_outputs_fatal_field_true(self) -> None:
+        """health_cmd --json sets fatal=true in JSON on fatal report."""
+        runner = CliRunner()
+        report = _make_fatal_report()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.session.load", return_value=None),
+            patch("composer.cli.health.check_all", return_value=report),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.checkpoint_dir.expanduser.return_value = Path("/tmp/checkpoints")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(health_cmd, ["--json"])
+
+        assert result.exit_code == 1
+        parsed = json.loads(result.output)
+        assert parsed["fatal"] is True
+        assert parsed["overall"] == "fail"
+
+    def test_text_output_calls_format_report(self) -> None:
+        """health_cmd without --json calls health.format_report and prints result."""
+        runner = CliRunner()
+        formatted = "breadmin-composer health check\n✓ Check A\nOverall: PASS"
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.session.load", return_value=None),
+            patch("composer.cli.health.check_all", return_value=_make_pass_report()),
+            patch("composer.cli.health.format_report", return_value=formatted),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.checkpoint_dir.expanduser.return_value = Path("/tmp/checkpoints")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(health_cmd, [])
+
+        assert result.exit_code == 0
+        assert formatted in result.output
+
+
+# ---------------------------------------------------------------------------
+# cost tests
+# ---------------------------------------------------------------------------
+
+
+class TestCostCmd:
+    def test_no_entries_prints_message(self) -> None:
+        """cost prints 'No cost entries found.' when ledger is empty."""
+        runner = CliRunner()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=[]),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, [])
+
+        assert result.exit_code == 0
+        assert "No cost entries found." in result.output
+
+    def test_aggregates_entries_correctly(self) -> None:
+        """cost aggregates input_tokens, output_tokens, and cost_usd by repo and stage."""
+        runner = CliRunner()
+        entries = [
+            _make_cost_entry(
+                repo="owner/repo",
+                stage="research",
+                input_tokens=1000,
+                output_tokens=200,
+                total_cost_usd=1.00,
+            ),
+            _make_cost_entry(
+                repo="owner/repo",
+                stage="research",
+                input_tokens=500,
+                output_tokens=100,
+                total_cost_usd=0.50,
+            ),
+        ]
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=entries),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, [])
+
+        assert result.exit_code == 0
+        output = result.output
+        # Should show 2 sessions aggregated
+        assert "2" in output
+        # Should show summed tokens
+        assert "1,500" in output  # input_tokens sum
+        assert "300" in output  # output_tokens sum
+        # Should show summed cost
+        assert "$1.50" in output
+        # Grand total
+        assert "Grand total" in output
+
+    def test_multiple_repos_printed_separately(self) -> None:
+        """cost prints a separate table per repo."""
+        runner = CliRunner()
+        entries = [
+            _make_cost_entry(repo="owner/repo1", stage="research"),
+            _make_cost_entry(repo="owner/repo2", stage="impl"),
+        ]
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=entries),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, [])
+
+        assert result.exit_code == 0
+        assert "Repo: owner/repo1" in result.output
+        assert "Repo: owner/repo2" in result.output
+
+    def test_repo_filter_applies(self) -> None:
+        """cost --repo filters entries to that repo only."""
+        runner = CliRunner()
+        # read_cost_ledger already handles filtering, but we pass the flag
+        entries = [
+            _make_cost_entry(repo="owner/repo1", stage="research"),
+        ]
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=entries) as mock_read,
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, ["--repo", "owner/repo1"])
+
+        assert result.exit_code == 0
+        # Verify read_cost_ledger was called with repo filter
+        mock_read.assert_called_once_with(
+            Path("/tmp/logs"),
+            repo="owner/repo1",
+            stage=None,
+        )
+        assert "Repo: owner/repo1" in result.output
+
+    def test_stage_filter_applies(self) -> None:
+        """cost --stage filters entries to that stage only."""
+        runner = CliRunner()
+        entries = [
+            _make_cost_entry(repo="owner/repo", stage="research"),
+        ]
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=entries) as mock_read,
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, ["--stage", "research"])
+
+        assert result.exit_code == 0
+        # Verify read_cost_ledger was called with stage filter
+        mock_read.assert_called_once_with(
+            Path("/tmp/logs"),
+            repo=None,
+            stage="research",
+        )
+
+    def test_null_cost_treated_as_zero(self) -> None:
+        """cost treats total_cost_usd=None as 0 in aggregation."""
+        runner = CliRunner()
+        entries = [
+            _make_cost_entry(
+                repo="owner/repo",
+                stage="research",
+                total_cost_usd=None,
+            ),
+        ]
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=entries),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, [])
+
+        assert result.exit_code == 0
+        assert "$0.00" in result.output
+
+    def test_grand_total_line_present(self) -> None:
+        """cost prints a grand total line at the bottom."""
+        runner = CliRunner()
+        entries = [
+            _make_cost_entry(repo="owner/repo", stage="research", total_cost_usd=2.50),
+        ]
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=entries),
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            result = runner.invoke(cost, [])
+
+        assert result.exit_code == 0
+        assert "Grand total across 1 repo(s): $2.50" in result.output
+
+    def test_no_startup_sequence_called(self) -> None:
+        """cost does NOT call startup_sequence (no orchestrator lock for admin cmd)."""
+        runner = CliRunner()
+        with (
+            patch.dict("os.environ", MINIMAL_ENV, clear=False),
+            patch("composer.cli.load_config") as mock_load_config,
+            patch("composer.cli.logger.read_cost_ledger", return_value=[]),
+            patch("composer.cli.startup_sequence") as mock_startup,
+        ):
+            mock_cfg = MagicMock()
+            mock_cfg.log_dir.expanduser.return_value = Path("/tmp/logs")
+            mock_load_config.return_value = mock_cfg
+
+            runner.invoke(cost, [])
+
+        mock_startup.assert_not_called()


### PR DESCRIPTION
## Summary

- Implements `composer health` subcommand: calls `health.check_all()`, prints status table via `health.format_report()`, exits 0 on pass/warn and 1 on fatal; `--json` flag outputs the `HealthReport` as indented JSON. Inline `dataclasses`/`json` imports moved to top of file.
- Implements `composer cost` subcommand: replaces the `startup_sequence` stub with a lightweight `load_config()` + `logger.read_cost_ledger()` flow; supports `--repo` and `--stage` filter options (passed directly to `read_cost_ledger`); groups entries by repo → stage; prints an ASCII table per repo with columns (Stage, Sessions, Input Tokens, Output Tokens, Est. Cost (USD)), a TOTAL row, and a grand total line across all repos; null `total_cost_usd` values contribute 0.
- Adds `tests/unit/test_cli_admin.py` with 14 unit tests covering all acceptance criteria.

## Test plan

- [x] `health_cmd` exits 0 on pass report
- [x] `health_cmd` exits 0 on warn report
- [x] `health_cmd` exits 1 on fatal report
- [x] `health_cmd --json` outputs valid JSON with `checks`, `overall`, `fatal` fields
- [x] `health_cmd --json` sets `fatal=true` on fatal report
- [x] `health_cmd` without `--json` calls `format_report` and prints output
- [x] `cost` with no entries prints "No cost entries found."
- [x] `cost` aggregates tokens and cost correctly across entries
- [x] `cost` prints separate table per repo
- [x] `cost --repo` passes filter to `read_cost_ledger`
- [x] `cost --stage` passes filter to `read_cost_ledger`
- [x] `cost` treats `total_cost_usd=None` as 0
- [x] `cost` prints grand total line
- [x] `cost` does NOT call `startup_sequence`
- [x] All 314 tests pass
- [x] `ruff check` and `ruff format --check` clean

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)