### PR TITLE
feat: add Glob and Grep to TOOLS_IMPL_AGENT

### DIFF
--- a/src/composer/runner.py
+++ b/src/composer/runner.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 TOOLS_RESEARCH: list[str] = ["gh", "bash", "read", "web_search"]
 TOOLS_DESIGN: list[str] = ["gh"]
-TOOLS_IMPL_AGENT: list[str] = ["gh", "bash", "read", "edit", "write"]
+TOOLS_IMPL_AGENT: list[str] = ["gh", "bash", "read", "edit", "write", "Glob", "Grep"]
 
 # ---------------------------------------------------------------------------
 # RunResult dataclass

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -124,7 +124,7 @@ def test_tools_design_contains_gh_only() -> None:
 
 
 def test_tools_impl_agent_contains_expected_tools() -> None:
-    assert set(TOOLS_IMPL_AGENT) == {"gh", "bash", "read", "edit", "write"}
+    assert set(TOOLS_IMPL_AGENT) == {"gh", "bash", "read", "edit", "write", "Glob", "Grep"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `"Glob"` and `"Grep"` to `TOOLS_IMPL_AGENT` in `src/composer/runner.py`
- Updates the corresponding assertion in `tests/unit/test_runner.py`

Per LLD §6.4, impl agents should have access to `Glob` and `Grep` for browsing the codebase during implementation.

Closes #152