### PR TITLE
infra: rename default branch main → mainline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [mainline]
   pull_request:
-    branches: [main]
+    branches: [mainline]
 
 jobs:
   test:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -3,7 +3,7 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    branches: [mainline]
 
 jobs:
   review:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ uv add --dev <package>    # add dev dependency
 
 ## Default Branch
 
-`main`
+`mainline`
 
 ## Pipeline Stage Tracking
 


### PR DESCRIPTION
## Summary
- Update `.github/workflows/ci.yml` branch triggers: `main` → `mainline`
- Update `.github/workflows/review.yml` branch trigger: `main` → `mainline`
- Update `CLAUDE.md` default branch declaration: `main` → `mainline`

GitHub branch rename was applied via the branches API prior to this PR.
PR #189 base was auto-updated by GitHub.

## Test plan
- [ ] CI passes
- [ ] Review workflow triggers on PRs targeting `mainline`

🤖 Generated with [Claude Code](https://claude.com/claude-code)