### PR TITLE
feat: add --repo argument to all entry points

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,12 @@ dependencies = [
 ]
 
 [project.scripts]
-impl-worker     = "composer.cli:impl_worker"
-research-worker = "composer.cli:research_worker"
-design-worker   = "composer.cli:design_worker"
-plan-issues     = "composer.cli:plan_issues"
-composer        = "composer.cli:composer"
+impl-worker      = "composer.cli:impl_worker"
+research-worker  = "composer.cli:research_worker"
+design-worker    = "composer.cli:design_worker"
+plan-issues      = "composer.cli:plan_issues"
+plan-milestones  = "composer.cli:plan_milestones"
+composer         = "composer.cli:composer"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/composer"]

--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -304,6 +304,263 @@ def _sanitize_issue_body(text: str, max_chars: int = MAX_PROMPT_CHARS) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _is_git_repo(path: str) -> bool:
+    """Return True if *path* is inside a git repository.
+
+    Runs ``git -C <path> rev-parse --git-dir`` and checks the exit code.
+
+    Args:
+        path: Filesystem path to test.
+
+    Returns:
+        True if the path is inside a git repo; False otherwise.
+    """
+    result = subprocess.run(
+        ["git", "-C", path, "rev-parse", "--git-dir"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _scaffold_new_repo(name: str) -> str:
+    """Create a new local directory, init git, and push to GitHub as a private repo.
+
+    Steps:
+      1. Create ``<name>/`` directory with a minimal README.md and .gitignore
+      2. ``git init``, ``git add .``, ``git commit -m "init"``
+      3. ``gh repo create <name> --private --source=. --push``
+
+    Args:
+        name: Repository name (no slashes). Used for directory and GitHub repo names.
+
+    Returns:
+        Absolute path to the newly-created local directory.
+
+    Raises:
+        click.ClickException: If directory creation, git init, or gh repo create fails.
+    """
+    repo_path = os.path.abspath(name)
+
+    if os.path.exists(repo_path):
+        raise click.ClickException(
+            f"Directory '{repo_path}' already exists. Remove it or choose a different name."
+        )
+
+    try:
+        os.makedirs(repo_path)
+    except OSError as exc:
+        raise click.ClickException(f"Failed to create directory '{repo_path}': {exc}") from exc
+
+    # Write a minimal README
+    readme_path = os.path.join(repo_path, "README.md")
+    with open(readme_path, "w", encoding="utf-8") as fh:
+        fh.write(f"# {name}\n\nInitialized by breadmin-composer.\n")
+
+    # Write a minimal .gitignore
+    gitignore_path = os.path.join(repo_path, ".gitignore")
+    with open(gitignore_path, "w", encoding="utf-8") as fh:
+        fh.write("__pycache__/\n*.pyc\n.env\n")
+
+    # git init
+    init = subprocess.run(
+        ["git", "init"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if init.returncode != 0:
+        raise click.ClickException(f"git init failed in '{repo_path}':\n{init.stderr}")
+
+    # git add .
+    add = subprocess.run(
+        ["git", "add", "."],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if add.returncode != 0:
+        raise click.ClickException(f"git add failed in '{repo_path}':\n{add.stderr}")
+
+    # git commit
+    commit = subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if commit.returncode != 0:
+        raise click.ClickException(f"git commit failed in '{repo_path}':\n{commit.stderr}")
+
+    # gh repo create
+    create = subprocess.run(
+        ["gh", "repo", "create", name, "--private", "--source=.", "--push"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+    )
+    if create.returncode != 0:
+        raise click.ClickException(f"gh repo create failed for '{name}':\n{create.stderr}")
+
+    return repo_path
+
+
+def _resolve_repo(repo_arg: str | None) -> tuple[str, str | None]:
+    """Resolve the ``--repo`` argument to a (repo_ref, local_path) pair.
+
+    The ``repo_ref`` is what gets passed to ``gh --repo``.  ``local_path`` is
+    the working directory for ``git`` commands (or ``None`` when the repo is
+    purely remote and already cloned via ``gh``).
+
+    Resolution rules
+    ----------------
+    1. ``repo_arg`` is ``None`` (no ``--repo`` flag)
+       → validate that cwd is a git repo; raise ClickException if not.
+       → return (github_remote_from_cwd, cwd)
+
+    2. ``repo_arg`` contains ``/`` and matches ``owner/name``
+       → treat as an existing remote repo; no local scaffolding.
+       → return (repo_arg, None)
+
+    3. ``repo_arg`` is a plain name with no ``/`` (no directory separators)
+       → scaffold a new private GitHub repo called ``name``.
+       → return (owner/name, abs_path_to_new_dir)
+
+    4. ``repo_arg`` is a path that contains ``os.sep`` or starts with ``.``
+       → treat as a local directory path; fail if not a git repo.
+       → return (github_remote_from_path, abs_path)
+
+    Args:
+        repo_arg: Raw value of the ``--repo`` CLI option, or ``None``.
+
+    Returns:
+        A ``(repo_ref, local_path)`` tuple where:
+        - ``repo_ref`` is a ``owner/name`` string (for ``gh --repo``) or an
+          empty string when the repo can only be identified by its local path.
+        - ``local_path`` is the absolute filesystem path, or ``None`` for a
+          purely remote operation.
+
+    Raises:
+        click.ClickException: On validation failure or scaffold error.
+    """
+    # -----------------------------------------------------------------------
+    # Case 1: No --repo flag → operate on cwd
+    # -----------------------------------------------------------------------
+    if repo_arg is None:
+        cwd = os.getcwd()
+        if not _is_git_repo(cwd):
+            raise click.ClickException(
+                "current directory is not a git repository.\n"
+                "Run from inside a git repo, or pass --repo <owner/name>."
+            )
+        # Try to infer owner/name from the remote URL
+        repo_ref = _infer_github_repo_from_path(cwd) or ""
+        return repo_ref, cwd
+
+    # -----------------------------------------------------------------------
+    # Case 2: Looks like "owner/name" — exactly two non-empty parts separated
+    # by a single "/" with no leading ".", no leading "/", and no additional "/"
+    # characters (so "a/b/c" or "./foo/bar" fall through to Case 3).
+    # -----------------------------------------------------------------------
+    _github_slug_re = re.compile(r"^[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+$")
+    if _github_slug_re.match(repo_arg):
+        return repo_arg, None
+
+    # -----------------------------------------------------------------------
+    # Case 3: Looks like a local path (starts with . or / or contains multiple
+    # path components that are not a two-part GitHub slug)
+    # -----------------------------------------------------------------------
+    if repo_arg.startswith(".") or repo_arg.startswith("/") or "/" in repo_arg:
+        abs_path = os.path.abspath(repo_arg)
+        if not os.path.isdir(abs_path):
+            raise click.ClickException(f"'{repo_arg}' is not a directory.")
+        if not _is_git_repo(abs_path):
+            raise click.ClickException(
+                f"'{abs_path}' is not a git repository.\n"
+                "Pass --repo <owner/name> to use a remote repo, or run from inside a git repo."
+            )
+        repo_ref = _infer_github_repo_from_path(abs_path) or ""
+        return repo_ref, abs_path
+
+    # -----------------------------------------------------------------------
+    # Case 4: Plain name with no slashes → scaffold a new private repo
+    # -----------------------------------------------------------------------
+    local_path = _scaffold_new_repo(repo_arg)
+    # After scaffolding, infer the remote owner/name
+    repo_ref = _infer_github_repo_from_path(local_path) or repo_arg
+    return repo_ref, local_path
+
+
+def _infer_github_repo_from_path(path: str) -> str | None:
+    """Infer the GitHub ``owner/name`` from the git remote URL at *path*.
+
+    Checks ``origin`` first, then falls back to the first remote found.
+    Handles both HTTPS (``https://github.com/owner/name.git``) and SSH
+    (``git@github.com:owner/name.git``) remote URL formats.
+
+    Args:
+        path: Absolute path to a git repository.
+
+    Returns:
+        ``owner/name`` string, or ``None`` if no GitHub remote is found.
+    """
+    result = subprocess.run(
+        ["git", "-C", path, "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Try listing all remotes
+        list_result = subprocess.run(
+            ["git", "-C", path, "remote"],
+            capture_output=True,
+            text=True,
+        )
+        if list_result.returncode != 0 or not list_result.stdout.strip():
+            return None
+        first_remote = list_result.stdout.strip().splitlines()[0]
+        result = subprocess.run(
+            ["git", "-C", path, "remote", "get-url", first_remote],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+
+    url = result.stdout.strip()
+    return _parse_github_owner_name(url)
+
+
+def _parse_github_owner_name(url: str) -> str | None:
+    """Extract ``owner/name`` from a GitHub remote URL.
+
+    Supports:
+    - ``https://github.com/owner/name.git``
+    - ``https://github.com/owner/name``
+    - ``git@github.com:owner/name.git``
+    - ``git@github.com:owner/name``
+
+    Args:
+        url: Remote URL string.
+
+    Returns:
+        ``owner/name`` without ``.git`` suffix, or ``None`` if not a GitHub URL.
+    """
+    import re as _re
+
+    # HTTPS: https://github.com/owner/name[.git]
+    https_match = _re.match(r"https?://github\.com/([^/]+/[^/]+?)(?:\.git)?$", url)
+    if https_match:
+        return https_match.group(1)
+
+    # SSH: git@github.com:owner/name[.git]
+    ssh_match = _re.match(r"git@github\.com:([^/]+/[^/]+?)(?:\.git)?$", url)
+    if ssh_match:
+        return ssh_match.group(1)
+
+    return None
+
+
 def _gh(
     args: list[str], *, repo: str | None = None, check: bool = True
 ) -> subprocess.CompletedProcess:
@@ -2614,12 +2871,113 @@ def _run_plan_issues(
 
 
 # ---------------------------------------------------------------------------
+# Plan-milestones helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_plan_milestones(
+    repo: str,
+    version: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    dry_run: bool = False,
+) -> None:
+    """Dispatch a single plan-milestones agent to create a milestone pair and seed issues.
+
+    Builds a prompt by injecting the ``plan-milestones`` skill file and
+    invoking ``runner.run()`` once. The agent reads the spec, creates
+    milestones, and files seed research issues.
+
+    Args:
+        repo:       GitHub repository in ``owner/repo`` format.
+        version:    Version identifier (e.g. ``"MVP"``, ``"v2"``).
+        config:     Validated Config instance.
+        checkpoint: Active Checkpoint instance.
+        dry_run:    If True, print the prompt length without executing.
+    """
+    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
+    today = date.today().isoformat()
+
+    base_prompt = (
+        f"## Session Parameters\n"
+        f"- Repository: {repo}\n"
+        f"- Version: {version}\n"
+        f"- Session Date: {today}\n\n"
+        f"You are the plan-milestones orchestrator for the `{repo}` repository.\n"
+        f"Read the spec at `docs/specs/{version}.md`, create the milestone pair, "
+        f"and file seed research issues following the skill instructions below."
+    )
+    prompt = inject_skill("plan-milestones", base_prompt)
+
+    if dry_run:
+        click.echo(
+            f"[dry-run] Would dispatch plan-milestones agent for version "
+            f"{version!r} in repo {repo!r}"
+        )
+        click.echo(f"[dry-run] Prompt length: {len(prompt)} chars")
+        return
+
+    logger.log_conductor_event(
+        run_id=checkpoint.run_id,
+        phase="dispatch",
+        event_type="plan_milestones_start",
+        payload={"repo": repo, "version": version},
+        log_dir=config.log_dir.expanduser(),
+    )
+
+    env = build_subprocess_env(config)
+    result = runner.run(
+        prompt=prompt,
+        allowed_tools=[
+            "Bash",
+            "Read",
+            "Glob",
+            "Grep",
+            "mcp__notion__API-post-page",
+        ],
+        env=env,
+        max_turns=200,
+    )
+
+    logger.log_conductor_event(
+        run_id=checkpoint.run_id,
+        phase="dispatch",
+        event_type="plan_milestones_complete",
+        payload={
+            "repo": repo,
+            "version": version,
+            "subtype": result.subtype,
+            "is_error": result.is_error,
+            "error_code": result.error_code,
+        },
+        log_dir=config.log_dir.expanduser(),
+    )
+    session.save(checkpoint, checkpoint_path)
+
+    if result.is_error:
+        click.echo(
+            f"Plan-milestones completed with error: {result.subtype} / {result.error_code}",
+            err=True,
+        )
+    else:
+        click.echo(f"Plan-milestones complete for version '{version}'.")
+
+
+# ---------------------------------------------------------------------------
 # Entry points
 # ---------------------------------------------------------------------------
 
 
 @click.command("impl-worker")
-@click.option("--repo", required=True, help="Target repo in OWNER/REPO format")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
 @click.option("--milestone", default=None, help="Milestone name to process")
 @click.option("--model", default=None, help="Override Claude model")
 @click.option("--max-budget", type=float, default=None, help="USD budget cap")
@@ -2627,7 +2985,7 @@ def _run_plan_issues(
 @click.option("--dry-run", is_flag=True, help="Print invocation without executing")
 @click.option("--resume", default=None, help="Resume a previous session by ID")
 def impl_worker(
-    repo: str,
+    repo: str | None,
     milestone: str | None,
     model: str | None,
     max_budget: float | None,
@@ -2636,7 +2994,8 @@ def impl_worker(
     resume: str | None,
 ) -> None:
     """Process implementation issues headlessly via claude -p."""
-    overrides: dict = {"github_repo": repo}
+    repo_ref, _local_path = _resolve_repo(repo)
+    overrides: dict = {"github_repo": repo_ref or None, "target_repo": repo_ref or None}
     if model:
         overrides["model"] = model
     if max_budget is not None:
@@ -2656,7 +3015,7 @@ def impl_worker(
     )
 
     _run_impl_worker(
-        repo=repo,
+        repo=repo_ref,
         milestone=milestone or "",
         config=_config,
         checkpoint=_checkpoint,
@@ -2665,7 +3024,15 @@ def impl_worker(
 
 
 @click.command("research-worker")
-@click.option("--repo", required=True, help="Target repo in OWNER/REPO format")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
 @click.option("--milestone", required=True, help="Milestone name to process")
 @click.option("--model", default=None, help="Override Claude model")
 @click.option("--max-budget", type=float, default=None, help="USD budget cap")
@@ -2673,7 +3040,7 @@ def impl_worker(
 @click.option("--dry-run", is_flag=True, help="Print invocation without executing")
 @click.option("--resume", default=None, help="Resume a previous session by ID")
 def research_worker(
-    repo: str,
+    repo: str | None,
     milestone: str,
     model: str | None,
     max_budget: float | None,
@@ -2682,7 +3049,8 @@ def research_worker(
     resume: str | None,
 ) -> None:
     """Process research issues for a milestone headlessly via claude -p."""
-    overrides: dict = {"github_repo": repo}
+    repo_ref, _local_path = _resolve_repo(repo)
+    overrides: dict = {"github_repo": repo_ref or None, "target_repo": repo_ref or None}
     if model:
         overrides["model"] = model
     if max_budget is not None:
@@ -2702,7 +3070,7 @@ def research_worker(
     )
 
     _run_research_worker(
-        repo=repo,
+        repo=repo_ref,
         milestone=milestone,
         config=_config,
         checkpoint=_checkpoint,
@@ -2711,20 +3079,29 @@ def research_worker(
 
 
 @click.command("design-worker")
-@click.option("--repo", required=True, help="Target repo in OWNER/REPO format")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
 @click.option(
     "--research-milestone", required=True, help="Completed research milestone to translate"
 )
 @click.option("--model", default=None, help="Override Claude model")
 @click.option("--dry-run", is_flag=True, help="Print planned issues without creating them")
 def design_worker(
-    repo: str,
+    repo: str | None,
     research_milestone: str,
     model: str | None,
     dry_run: bool,
 ) -> None:
     """Translate research docs into HLD and LLD design documents via claude -p."""
-    overrides: dict = {"github_repo": repo}
+    repo_ref, _local_path = _resolve_repo(repo)
+    overrides: dict = {"github_repo": repo_ref or None, "target_repo": repo_ref or None}
     if model:
         overrides["model"] = model
 
@@ -2739,7 +3116,7 @@ def design_worker(
     )
 
     _run_design_worker(
-        repo=repo,
+        repo=repo_ref,
         research_milestone=research_milestone,
         config=_config,
         checkpoint=_checkpoint,
@@ -2748,20 +3125,29 @@ def design_worker(
 
 
 @click.command("plan-issues")
-@click.option("--repo", required=True, help="Target repo in OWNER/REPO format")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
 @click.option(
     "--impl-milestone", required=True, help="Implementation milestone to file issues against"
 )
 @click.option("--model", default=None, help="Override Claude model")
 @click.option("--dry-run", is_flag=True, help="Print planned milestones without creating them")
 def plan_issues(
-    repo: str,
+    repo: str | None,
     impl_milestone: str,
     model: str | None,
     dry_run: bool,
 ) -> None:
     """File stage/impl issues from HLD and LLD design docs via claude -p."""
-    overrides: dict = {"github_repo": repo}
+    repo_ref, _local_path = _resolve_repo(repo)
+    overrides: dict = {"github_repo": repo_ref or None, "target_repo": repo_ref or None}
     if model:
         overrides["model"] = model
 
@@ -2776,8 +3162,52 @@ def plan_issues(
     )
 
     _run_plan_issues(
-        repo=repo,
+        repo=repo_ref,
         impl_milestone=impl_milestone,
+        config=_config,
+        checkpoint=_checkpoint,
+        dry_run=dry_run,
+    )
+
+
+@click.command("plan-milestones")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
+@click.option("--version", required=True, help="Version name (e.g. 'MVP', 'v2')")
+@click.option("--model", default=None, help="Override Claude model")
+@click.option("--dry-run", is_flag=True, help="Print planned milestones without creating them")
+def plan_milestones(
+    repo: str | None,
+    version: str,
+    model: str | None,
+    dry_run: bool,
+) -> None:
+    """Create a milestone pair and seed research issues from a spec via claude -p."""
+    repo_ref, _local_path = _resolve_repo(repo)
+    overrides: dict = {"github_repo": repo_ref or None, "target_repo": repo_ref or None}
+    if model:
+        overrides["model"] = model
+
+    config = load_config(**overrides)
+    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
+
+    _config, _checkpoint = startup_sequence(
+        config=config,
+        checkpoint_path=checkpoint_path,
+        milestone=version,
+        stage="plan-milestones",
+    )
+
+    _run_plan_milestones(
+        repo=repo_ref,
+        version=version,
         config=_config,
         checkpoint=_checkpoint,
         dry_run=dry_run,
@@ -2790,11 +3220,24 @@ def composer() -> None:
 
 
 @composer.command("health")
-@click.option("--repo", default=None, help="Repo to check (OWNER/REPO)")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 def health_cmd(repo: str | None, as_json: bool) -> None:
     """Run preflight checks."""
-    config = load_config(**({} if not repo else {"github_repo": repo}))
+    repo_ref, _local_path = _resolve_repo(repo)
+    overrides: dict = {}
+    if repo_ref:
+        overrides["github_repo"] = repo_ref
+        overrides["target_repo"] = repo_ref
+    config = load_config(**overrides)
     checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
     chk = session.load(checkpoint_path)
     report = health.check_all(config, chk)

--- a/src/composer/config.py
+++ b/src/composer/config.py
@@ -115,6 +115,15 @@ class Config(BaseSettings):
         validation_alias=AliasChoices("GITHUB_REPO", "github_repo"),
         description='GitHub repository in "owner/repo" format',
     )
+    target_repo: str | None = Field(
+        default=None,
+        description=(
+            "Resolved target repository. "
+            "For remote repos: 'owner/name' string. "
+            "For local repos: absolute path string. "
+            "None means operate on the current working directory."
+        ),
+    )
 
     # --- Health checks ---
     max_orphaned_issues: int = Field(

--- a/src/composer/skills/design-worker.md
+++ b/src/composer/skills/design-worker.md
@@ -4,12 +4,26 @@ The design worker translates completed research into HLD and LLD design document
 It runs **after** research is declared complete (research-worker Step 4 verdict) and **before**
 plan-issues begins. It produces no code and no GitHub issues — only design documents.
 
+## Target Repository
+
+The `--repo` argument controls which repository this worker operates on:
+
+| Invocation | Behaviour |
+|---|---|
+| *(no flag)* | Operate on the current working directory. Fails if cwd is not a git repo. |
+| `--repo owner/name` | Operate on an existing remote GitHub repo. All `gh` commands use `--repo owner/name`. |
+| `--repo name` | Scaffold a new private GitHub repo named `name`, then operate on it. |
+| `--repo path/to/local/dir` | Operate on the local directory. Fails if it is not a git repo. |
+
+All `gh` commands in this skill must be scoped with `--repo <owner>/<name>` when the target is a remote repo.
+All `git` commands must be run with `-C <local_path>` (or inside the cloned directory) when operating on a local path.
+
 ## Setup
 
 1. Detect the default branch:
    ```bash
-   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
-   git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+   DEFAULT_BRANCH=$(gh repo view --repo <owner>/<repo> --json defaultBranchRef --jq '.defaultBranchRef.name')
+   git -C <local_path> checkout $DEFAULT_BRANCH && git -C <local_path> pull origin $DEFAULT_BRANCH
    ```
 
 2. Run startup checks per the Orchestrator-Dispatch Protocol in ~/.claude/CLAUDE.md.
@@ -20,7 +34,7 @@ plan-issues begins. It produces no code and no GitHub issues — only design doc
 
 The design worker requires:
 - `--research-milestone` — the research milestone whose docs to translate
-- `--repo` — the target repository
+- `--repo` — the target repository (optional; defaults to cwd)
 
 ## Execution
 

--- a/src/composer/skills/impl-worker.md
+++ b/src/composer/skills/impl-worker.md
@@ -1,15 +1,29 @@
 Start the issue worker orchestrator for this repository in autonomous mode.
 
+## Target Repository
+
+The `--repo` argument controls which repository this worker operates on:
+
+| Invocation | Behaviour |
+|---|---|
+| *(no flag)* | Operate on the current working directory. Fails if cwd is not a git repo. |
+| `--repo owner/name` | Operate on an existing remote GitHub repo. All `gh` commands use `--repo owner/name`. |
+| `--repo name` | Scaffold a new private GitHub repo named `name`, then operate on it. |
+| `--repo path/to/local/dir` | Operate on the local directory. Fails if it is not a git repo. |
+
+All `gh` commands in this skill must be scoped with `--repo <owner>/<name>` when the target is a remote repo.
+All `git` commands must be run with `-C <local_path>` (or inside the cloned directory) when operating on a local path.
+
 ## Setup
 
 1. Detect the default branch:
    ```bash
-   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+   DEFAULT_BRANCH=$(gh repo view --repo <owner>/<repo> --json defaultBranchRef --jq '.defaultBranchRef.name')
    ```
 
 2. Ensure you're on the default branch:
    ```bash
-   git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+   git -C <local_path> checkout $DEFAULT_BRANCH && git -C <local_path> pull origin $DEFAULT_BRANCH
    ```
 
 3. Run startup checks per the Orchestrator-Dispatch Protocol in ~/.claude/CLAUDE.md:

--- a/src/composer/skills/plan-issues.md
+++ b/src/composer/skills/plan-issues.md
@@ -6,12 +6,26 @@ test requirements, and a verified dependency graph. It runs **after** design-wor
 all design docs and **before** impl-worker begins. It creates GitHub issues only — no code,
 no design docs, no source file changes.
 
+## Target Repository
+
+The `--repo` argument controls which repository this worker operates on:
+
+| Invocation | Behaviour |
+|---|---|
+| *(no flag)* | Operate on the current working directory. Fails if cwd is not a git repo. |
+| `--repo owner/name` | Operate on an existing remote GitHub repo. All `gh` commands use `--repo owner/name`. |
+| `--repo name` | Scaffold a new private GitHub repo named `name`, then operate on it. |
+| `--repo path/to/local/dir` | Operate on the local directory. Fails if it is not a git repo. |
+
+All `gh` commands in this skill must be scoped with `--repo <owner>/<name>` when the target is a remote repo.
+All `git` commands must be run with `-C <local_path>` (or inside the cloned directory) when operating on a local path.
+
 ## Setup
 
 1. Detect the default branch:
    ```bash
-   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
-   git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+   DEFAULT_BRANCH=$(gh repo view --repo <owner>/<repo> --json defaultBranchRef --jq '.defaultBranchRef.name')
+   git -C <local_path> checkout $DEFAULT_BRANCH && git -C <local_path> pull origin $DEFAULT_BRANCH
    ```
 
 2. Run startup checks per the Orchestrator-Dispatch Protocol in ~/.claude/CLAUDE.md.
@@ -21,7 +35,7 @@ no design docs, no source file changes.
 ## Inputs
 
 The plan-issues orchestrator requires:
-- `--repo` — the target repository in `OWNER/REPO` format
+- `--repo` — the target repository (optional; defaults to cwd)
 - `--impl-milestone` — the implementation milestone to file issues against
 
 Verify the impl milestone exists:

--- a/src/composer/skills/plan-milestones.md
+++ b/src/composer/skills/plan-milestones.md
@@ -10,11 +10,25 @@ Run this at two points:
 - When impl-worker begins a version (plan the research phase for version N+1)
 - Never plan more than one version ahead — research findings change scope
 
+## Target Repository
+
+The `--repo` argument controls which repository this worker operates on:
+
+| Invocation | Behaviour |
+|---|---|
+| *(no flag)* | Operate on the current working directory. Fails if cwd is not a git repo. |
+| `--repo owner/name` | Operate on an existing remote GitHub repo. All `gh` commands use `--repo owner/name`. |
+| `--repo name` | Scaffold a new private GitHub repo named `name`, then operate on it. |
+| `--repo path/to/local/dir` | Operate on the local directory. Fails if it is not a git repo. |
+
+All `gh` commands in this skill must be scoped with `--repo <owner>/<name>` when the target is a remote repo.
+All `git` commands must be run with `-C <local_path>` (or inside the cloned directory) when operating on a local path.
+
 ## Setup
 
 ```bash
-DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
-git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+DEFAULT_BRANCH=$(gh repo view --repo <owner>/<repo> --json defaultBranchRef --jq '.defaultBranchRef.name')
+git -C <local_path> checkout $DEFAULT_BRANCH && git -C <local_path> pull origin $DEFAULT_BRANCH
 ```
 
 Read the project CLAUDE.md to understand the domain and constraints.

--- a/src/composer/skills/research-worker.md
+++ b/src/composer/skills/research-worker.md
@@ -5,16 +5,30 @@ completed research for follow-up topics, creating follow-up issues, and re-dispa
 the **active milestone's** research queue is empty. This is distinct from the `issue-worker`
 command which handles implementation tasks.
 
+## Target Repository
+
+The `--repo` argument controls which repository this worker operates on:
+
+| Invocation | Behaviour |
+|---|---|
+| *(no flag)* | Operate on the current working directory. Fails if cwd is not a git repo. |
+| `--repo owner/name` | Operate on an existing remote GitHub repo. All `gh` commands use `--repo owner/name`. |
+| `--repo name` | Scaffold a new private GitHub repo named `name`, then operate on it. |
+| `--repo path/to/local/dir` | Operate on the local directory. Fails if it is not a git repo. |
+
+All `gh` commands in this skill must be scoped with `--repo <owner>/<name>` when the target is a remote repo.
+All `git` commands must be run with `-C <local_path>` (or inside the cloned directory) when operating on a local path.
+
 ## Setup
 
 1. Detect the default branch:
    ```bash
-   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+   DEFAULT_BRANCH=$(gh repo view --repo <owner>/<repo> --json defaultBranchRef --jq '.defaultBranchRef.name')
    ```
 
 2. Ensure you're on the default branch:
    ```bash
-   git checkout $DEFAULT_BRANCH && git pull origin $DEFAULT_BRANCH
+   git -C <local_path> checkout $DEFAULT_BRANCH && git -C <local_path> pull origin $DEFAULT_BRANCH
    ```
 
 3. Run startup checks per the Orchestrator-Dispatch Protocol in ~/.claude/CLAUDE.md:

--- a/tests/unit/test_cli_design.py
+++ b/tests/unit/test_cli_design.py
@@ -408,11 +408,13 @@ class TestRunPlanIssues:
 
 
 class TestDesignWorkerCommand:
-    def test_missing_repo_fails(self) -> None:
+    def test_no_repo_outside_git_dir_fails(self, tmp_path: Path) -> None:
+        """design-worker without --repo fails when cwd is not a git repo."""
         runner = CliRunner()
-        result = runner.invoke(design_worker, ["--research-milestone", "v1"])
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(design_worker, ["--research-milestone", "v1"])
         assert result.exit_code != 0
-        assert "Missing option" in result.output or "--repo" in result.output
+        assert "not a git repository" in result.output or "Error" in result.output
 
     def test_missing_research_milestone_fails(self) -> None:
         runner = CliRunner()
@@ -453,11 +455,13 @@ class TestDesignWorkerCommand:
 
 
 class TestPlanIssuesCommand:
-    def test_missing_repo_fails(self) -> None:
+    def test_no_repo_outside_git_dir_fails(self, tmp_path: Path) -> None:
+        """plan-issues without --repo fails when cwd is not a git repo."""
         runner = CliRunner()
-        result = runner.invoke(plan_issues, ["--impl-milestone", "v1"])
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(plan_issues, ["--impl-milestone", "v1"])
         assert result.exit_code != 0
-        assert "Missing option" in result.output or "--repo" in result.output
+        assert "not a git repository" in result.output or "Error" in result.output
 
     def test_missing_impl_milestone_fails(self) -> None:
         runner = CliRunner()

--- a/tests/unit/test_cli_repo.py
+++ b/tests/unit/test_cli_repo.py
@@ -1,0 +1,296 @@
+"""Unit tests for --repo argument resolution in src/composer/cli.py."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from composer.cli import (
+    _is_git_repo,
+    _parse_github_owner_name,
+    _resolve_repo,
+    _scaffold_new_repo,
+)
+
+# ---------------------------------------------------------------------------
+# _is_git_repo
+# ---------------------------------------------------------------------------
+
+
+class TestIsGitRepo:
+    def test_returns_true_for_valid_git_repo(self, tmp_path: Path) -> None:
+        """_is_git_repo returns True for a directory that is a git repo."""
+        subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+        assert _is_git_repo(str(tmp_path)) is True
+
+    def test_returns_false_for_plain_directory(self, tmp_path: Path) -> None:
+        """_is_git_repo returns False for a plain directory with no git."""
+        assert _is_git_repo(str(tmp_path)) is False
+
+    def test_returns_false_for_nonexistent_path(self, tmp_path: Path) -> None:
+        """_is_git_repo returns False for a path that does not exist."""
+        assert _is_git_repo(str(tmp_path / "does_not_exist")) is False
+
+
+# ---------------------------------------------------------------------------
+# _parse_github_owner_name
+# ---------------------------------------------------------------------------
+
+
+class TestParseGithubOwnerName:
+    def test_parses_https_url_with_git_suffix(self) -> None:
+        url = "https://github.com/owner/myrepo.git"
+        assert _parse_github_owner_name(url) == "owner/myrepo"
+
+    def test_parses_https_url_without_git_suffix(self) -> None:
+        url = "https://github.com/owner/myrepo"
+        assert _parse_github_owner_name(url) == "owner/myrepo"
+
+    def test_parses_ssh_url_with_git_suffix(self) -> None:
+        url = "git@github.com:owner/myrepo.git"
+        assert _parse_github_owner_name(url) == "owner/myrepo"
+
+    def test_parses_ssh_url_without_git_suffix(self) -> None:
+        url = "git@github.com:owner/myrepo"
+        assert _parse_github_owner_name(url) == "owner/myrepo"
+
+    def test_returns_none_for_non_github_url(self) -> None:
+        url = "https://gitlab.com/owner/myrepo.git"
+        assert _parse_github_owner_name(url) is None
+
+    def test_returns_none_for_empty_string(self) -> None:
+        assert _parse_github_owner_name("") is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_repo — cwd validation (no --repo flag)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRepoCwdMode:
+    def test_no_repo_in_git_dir_succeeds(self, tmp_path: Path) -> None:
+        """No --repo flag succeeds when cwd is a git repo."""
+        subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            with patch("composer.cli._infer_github_repo_from_path", return_value="owner/repo"):
+                repo_ref, local_path = _resolve_repo(None)
+        assert repo_ref == "owner/repo"
+        assert local_path == str(tmp_path)
+
+    def test_no_repo_outside_git_dir_raises(self, tmp_path: Path) -> None:
+        """No --repo flag fails with ClickException when cwd is not a git repo."""
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            with pytest.raises(click.ClickException) as exc_info:
+                _resolve_repo(None)
+        assert "not a git repository" in str(exc_info.value.format_message())
+        assert "--repo" in str(exc_info.value.format_message())
+
+    def test_error_message_suggests_repo_flag(self, tmp_path: Path) -> None:
+        """The cwd error message suggests using --repo <owner/name>."""
+        with patch("os.getcwd", return_value=str(tmp_path)):
+            with pytest.raises(click.ClickException) as exc_info:
+                _resolve_repo(None)
+        msg = exc_info.value.format_message()
+        assert "owner/name" in msg or "--repo" in msg
+
+
+# ---------------------------------------------------------------------------
+# _resolve_repo — owner/name remote repo
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRepoRemoteMode:
+    def test_owner_name_returns_repo_ref_and_no_local_path(self) -> None:
+        """'owner/name' format returns (owner/name, None) without touching disk."""
+        repo_ref, local_path = _resolve_repo("bread-wood/calculator-cli")
+        assert repo_ref == "bread-wood/calculator-cli"
+        assert local_path is None
+
+    def test_owner_name_with_dashes_and_underscores(self) -> None:
+        """Complex owner/name strings are accepted as-is."""
+        repo_ref, local_path = _resolve_repo("my-org/my_repo-v2")
+        assert repo_ref == "my-org/my_repo-v2"
+        assert local_path is None
+
+    def test_owner_name_does_not_call_scaffold(self) -> None:
+        """owner/name format does NOT trigger _scaffold_new_repo."""
+        with patch("composer.cli._scaffold_new_repo") as mock_scaffold:
+            _resolve_repo("owner/name")
+        mock_scaffold.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _resolve_repo — new repo scaffolding (plain name, no slash)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRepoScaffoldMode:
+    def test_plain_name_triggers_scaffold(self, tmp_path: Path) -> None:
+        """Plain name (no slash) triggers _scaffold_new_repo."""
+        fake_path = str(tmp_path / "mynewrepo")
+        with patch("composer.cli._scaffold_new_repo", return_value=fake_path) as mock_scaffold:
+            with patch(
+                "composer.cli._infer_github_repo_from_path",
+                return_value="myuser/mynewrepo",
+            ):
+                repo_ref, local_path = _resolve_repo("mynewrepo")
+        mock_scaffold.assert_called_once_with("mynewrepo")
+        assert local_path == fake_path
+
+    def test_scaffold_called_with_correct_name(self, tmp_path: Path) -> None:
+        """The name passed to _scaffold_new_repo matches the CLI argument."""
+        fake_path = str(tmp_path / "calculator-cli")
+        with patch("composer.cli._scaffold_new_repo", return_value=fake_path) as mock_scaffold:
+            with patch("composer.cli._infer_github_repo_from_path", return_value=None):
+                _resolve_repo("calculator-cli")
+        mock_scaffold.assert_called_once_with("calculator-cli")
+
+    def test_scaffold_returns_repo_ref_from_infer(self, tmp_path: Path) -> None:
+        """When _infer_github_repo_from_path succeeds, repo_ref is owner/name."""
+        fake_path = str(tmp_path / "testapp")
+        with patch("composer.cli._scaffold_new_repo", return_value=fake_path):
+            with patch(
+                "composer.cli._infer_github_repo_from_path",
+                return_value="bread-wood/testapp",
+            ):
+                repo_ref, _ = _resolve_repo("testapp")
+        assert repo_ref == "bread-wood/testapp"
+
+    def test_scaffold_falls_back_to_name_when_infer_fails(self, tmp_path: Path) -> None:
+        """When _infer_github_repo_from_path returns None, repo_ref is the name."""
+        fake_path = str(tmp_path / "testapp")
+        with patch("composer.cli._scaffold_new_repo", return_value=fake_path):
+            with patch("composer.cli._infer_github_repo_from_path", return_value=None):
+                repo_ref, _ = _resolve_repo("testapp")
+        assert repo_ref == "testapp"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_repo — local path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRepoLocalPathMode:
+    def test_local_path_that_is_git_repo_succeeds(self, tmp_path: Path) -> None:
+        """Local path that is a git repo returns (inferred_ref, abs_path)."""
+        subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+        with patch(
+            "composer.cli._infer_github_repo_from_path",
+            return_value="owner/mylocal",
+        ):
+            repo_ref, local_path = _resolve_repo(str(tmp_path))
+        assert local_path == str(tmp_path)
+        assert repo_ref == "owner/mylocal"
+
+    def test_local_path_not_git_repo_raises(self, tmp_path: Path) -> None:
+        """Local path that is NOT a git repo raises ClickException."""
+        non_git = str(tmp_path)
+        with pytest.raises(click.ClickException) as exc_info:
+            _resolve_repo(non_git)
+        assert "not a git repository" in str(exc_info.value.format_message())
+
+    def test_relative_dot_path_resolves_to_abs(self, tmp_path: Path) -> None:
+        """Relative path starting with '.' is expanded to absolute path."""
+        subprocess.run(["git", "init"], cwd=str(tmp_path), check=True, capture_output=True)
+        # Change cwd so "." resolves to tmp_path
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(str(tmp_path))
+            with patch(
+                "composer.cli._infer_github_repo_from_path",
+                return_value=None,
+            ):
+                repo_ref, local_path = _resolve_repo(".")
+            assert local_path == str(tmp_path)
+        finally:
+            os.chdir(original_cwd)
+
+    def test_nonexistent_path_raises(self, tmp_path: Path) -> None:
+        """A path that doesn't exist raises ClickException."""
+        missing = str(tmp_path / "no" / "such" / "dir")
+        with pytest.raises(click.ClickException) as exc_info:
+            _resolve_repo(missing)
+        assert "not a directory" in str(exc_info.value.format_message()).lower()
+
+
+# ---------------------------------------------------------------------------
+# _scaffold_new_repo (mock gh)
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldNewRepo:
+    def test_creates_readme_and_gitignore(self, tmp_path: Path) -> None:
+        """_scaffold_new_repo creates README.md and .gitignore in the new dir."""
+        parent = tmp_path / "workspace"
+        parent.mkdir()
+
+        # Patch os.path.abspath to return predictable path inside tmp_path
+        repo_dir = str(parent / "myproject")
+
+        original_abspath = os.path.abspath
+
+        def fake_abspath(p: str) -> str:
+            if p == "myproject":
+                return repo_dir
+            return original_abspath(p)
+
+        mock_run = MagicMock()
+        # All subprocess calls succeed
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+
+        with (
+            patch("os.path.abspath", side_effect=fake_abspath),
+            patch("subprocess.run", mock_run),
+        ):
+            result = _scaffold_new_repo("myproject")
+
+        assert result == repo_dir
+
+    def test_raises_if_directory_already_exists(self, tmp_path: Path) -> None:
+        """_scaffold_new_repo raises ClickException if the target dir already exists."""
+        existing_dir = tmp_path / "existing"
+        existing_dir.mkdir()
+
+        original_abspath = os.path.abspath
+
+        def fake_abspath(p: str) -> str:
+            if p == "existing":
+                return str(existing_dir)
+            return original_abspath(p)
+
+        with patch("os.path.abspath", side_effect=fake_abspath):
+            with pytest.raises(click.ClickException) as exc_info:
+                _scaffold_new_repo("existing")
+        assert "already exists" in str(exc_info.value.format_message())
+
+    def test_raises_if_gh_repo_create_fails(self, tmp_path: Path) -> None:
+        """_scaffold_new_repo raises ClickException if gh repo create fails."""
+        repo_dir = str(tmp_path / "failproject")
+        original_abspath = os.path.abspath
+
+        def fake_abspath(p: str) -> str:
+            if p == "failproject":
+                return repo_dir
+            return original_abspath(p)
+
+        call_count = [0]
+
+        def mock_run(cmd: list, **kwargs):  # type: ignore[no-untyped-def]
+            call_count[0] += 1
+            # Fail on gh repo create (last call)
+            if cmd[0] == "gh":
+                return MagicMock(returncode=1, stderr="not authenticated", stdout="")
+            return MagicMock(returncode=0, stderr="", stdout="")
+
+        with (
+            patch("os.path.abspath", side_effect=fake_abspath),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            with pytest.raises(click.ClickException) as exc_info:
+                _scaffold_new_repo("failproject")
+        assert "gh repo create failed" in str(exc_info.value.format_message())


### PR DESCRIPTION
## Summary

- Adds optional `--repo` argument to all worker entry points (`research-worker`, `design-worker`, `plan-issues`, `impl-worker`, `plan-milestones`) and `composer health`
- No `--repo` flag: operates on the current working directory; fails with a clear error if cwd is not a git repository
- `--repo owner/name`: uses an existing remote GitHub repo
- `--repo name` (no slash): scaffolds a new private GitHub repo via `gh repo create`
- `--repo path/to/local/dir`: operates on a local directory; fails if not a git repo
- Adds `target_repo` field to `Config` dataclass
- Adds `plan-milestones` entry point to `pyproject.toml` (was missing)
- Updates all skill files with a **Target Repository** section documenting `--repo` modes and scoping rules for `gh`/`git` commands

## Test plan

- [x] 26 new unit tests covering all four `--repo` resolution modes, scaffold error paths, and URL parsing helpers
- [x] 2 existing tests updated to match new optional-`--repo` behaviour
- [x] `uv run pytest -q` — 399 tests pass
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)