### PR TITLE
feat: add composer run full-pipeline command

### DIFF
--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -3385,3 +3385,269 @@ def cost() -> None:
         stage="cost",
     )
     click.echo("Not yet implemented")
+
+
+# ---------------------------------------------------------------------------
+# run — full pipeline orchestration
+# ---------------------------------------------------------------------------
+
+# Valid stage names in pipeline order
+_PIPELINE_STAGES: list[str] = [
+    "plan-milestones",
+    "research-worker",
+    "design-worker",
+    "plan-issues",
+    "impl-worker",
+]
+
+
+def _run_pipeline_stage(
+    stage: str,
+    repo_ref: str,
+    local_path: str | None,
+    version: str,
+    spec: str | None,
+    dry_run: bool,
+) -> None:
+    """Execute a single pipeline stage by calling the underlying _run_* helper.
+
+    Builds a minimal Config and Checkpoint for the stage, then delegates to the
+    appropriate internal helper function.  Each stage is self-contained: it loads
+    its own config and checkpoint so that stages remain independent.
+
+    Args:
+        stage:      One of the valid _PIPELINE_STAGES names.
+        repo_ref:   Resolved ``owner/name`` repository reference.
+        local_path: Absolute path to the local repo clone (or None for remote-only).
+        version:    Version identifier (e.g. ``"MVP"``).
+        spec:       Absolute path to a spec file to seed (plan-milestones only, or None).
+        dry_run:    If True, print intent without executing.
+
+    Raises:
+        click.ClickException: On configuration or stage-level failures.
+    """
+    overrides: dict = {
+        "github_repo": repo_ref or None,
+        "target_repo": repo_ref or None,
+    }
+    config = load_config(**overrides)
+    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
+
+    research_milestone = f"{version} Research"
+    impl_milestone = f"{version} Implementation"
+
+    if stage == "plan-milestones":
+        _config, _checkpoint = startup_sequence(
+            config=config,
+            checkpoint_path=checkpoint_path,
+            milestone=version,
+            stage="plan-milestones",
+        )
+        # Seed spec if provided
+        if spec is not None:
+            resolved_spec = Path(spec)
+            if local_path is None:
+                raise click.ClickException(
+                    "--spec requires a local repository path. "
+                    "Pass --repo path/to/local/dir or omit --repo to operate on cwd."
+                )
+            _seed_spec(resolved_spec, version, local_path)
+        _run_plan_milestones(
+            repo=repo_ref,
+            version=version,
+            config=_config,
+            checkpoint=_checkpoint,
+            dry_run=dry_run,
+        )
+
+    elif stage == "research-worker":
+        _config, _checkpoint = startup_sequence(
+            config=config,
+            checkpoint_path=checkpoint_path,
+            milestone=research_milestone,
+            stage="research",
+        )
+        _run_research_worker(
+            repo=repo_ref,
+            milestone=research_milestone,
+            config=_config,
+            checkpoint=_checkpoint,
+            dry_run=dry_run,
+        )
+
+    elif stage == "design-worker":
+        _config, _checkpoint = startup_sequence(
+            config=config,
+            checkpoint_path=checkpoint_path,
+            milestone=research_milestone,
+            stage="design",
+        )
+        _run_design_worker(
+            repo=repo_ref,
+            research_milestone=research_milestone,
+            config=_config,
+            checkpoint=_checkpoint,
+            dry_run=dry_run,
+        )
+
+    elif stage == "plan-issues":
+        _config, _checkpoint = startup_sequence(
+            config=config,
+            checkpoint_path=checkpoint_path,
+            milestone=impl_milestone,
+            stage="plan-issues",
+        )
+        _run_plan_issues(
+            repo=repo_ref,
+            impl_milestone=impl_milestone,
+            config=_config,
+            checkpoint=_checkpoint,
+            dry_run=dry_run,
+        )
+
+    elif stage == "impl-worker":
+        _config, _checkpoint = startup_sequence(
+            config=config,
+            checkpoint_path=checkpoint_path,
+            milestone=impl_milestone,
+            stage="impl",
+        )
+        _run_impl_worker(
+            repo=repo_ref,
+            milestone=impl_milestone,
+            config=_config,
+            checkpoint=_checkpoint,
+            dry_run=dry_run,
+        )
+
+    else:
+        raise click.ClickException(f"Unknown pipeline stage: {stage!r}")
+
+
+@composer.command("run")
+@click.option(
+    "--repo",
+    default=None,
+    help=(
+        "Target repository. Accepts: 'owner/name' (existing remote), "
+        "'name' (new private repo to scaffold), 'path/to/local/dir' (local git repo), "
+        "or omit to operate on the current working directory."
+    ),
+)
+@click.option(
+    "--spec",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help=(
+        "Path to a .md spec file to seed into the target repo before running plan-milestones. "
+        "Accepts relative (resolved from cwd) or absolute paths."
+    ),
+)
+@click.option(
+    "--version",
+    default=None,
+    help=(
+        "Version name override (e.g. 'MVP', 'v2'). "
+        "Defaults to the spec filename stem when --spec is given."
+    ),
+)
+@click.option(
+    "--from",
+    "from_stage",
+    default=None,
+    help=(
+        "Resume from a specific stage, skipping earlier ones. "
+        f"Valid values: {', '.join(_PIPELINE_STAGES)}"
+    ),
+)
+@click.option("--dry-run", is_flag=True, help="Print what each stage would do without executing")
+def run(
+    repo: str | None,
+    spec: str | None,
+    version: str | None,
+    from_stage: str | None,
+    dry_run: bool,
+) -> None:
+    """Run the full pipeline end-to-end.
+
+    Stages: plan-milestones → research-worker → design-worker → plan-issues → impl-worker.
+    """
+    # -----------------------------------------------------------------------
+    # Validate --from
+    # -----------------------------------------------------------------------
+    if from_stage is not None and from_stage not in _PIPELINE_STAGES:
+        raise click.UsageError(
+            f"Invalid --from value: {from_stage!r}. Valid values: {', '.join(_PIPELINE_STAGES)}"
+        )
+
+    # -----------------------------------------------------------------------
+    # Validate --spec and derive --version
+    # -----------------------------------------------------------------------
+    resolved_spec: Path | None = None
+    if spec is not None:
+        resolved_spec = _validate_spec_path(spec)
+
+    if version is None:
+        if resolved_spec is not None:
+            version = resolved_spec.stem
+        else:
+            raise click.UsageError(
+                "--version is required when --spec is not provided. "
+                "Pass --version MVP (or another version name) to identify the milestone pair."
+            )
+
+    # -----------------------------------------------------------------------
+    # Resolve repo
+    # -----------------------------------------------------------------------
+    repo_ref, local_path = _resolve_repo(repo)
+
+    # -----------------------------------------------------------------------
+    # Determine which stages to skip based on --from
+    # -----------------------------------------------------------------------
+    start_index = 0
+    if from_stage is not None:
+        start_index = _PIPELINE_STAGES.index(from_stage)
+
+    # -----------------------------------------------------------------------
+    # Run each stage in order
+    # -----------------------------------------------------------------------
+    for idx, stage in enumerate(_PIPELINE_STAGES):
+        click.echo(f"\n── Stage: {stage} ──")
+
+        if idx < start_index:
+            click.echo(f"[skip] {stage}")
+            continue
+
+        if dry_run:
+            click.echo(f"[dry-run] would invoke {stage}")
+            continue
+
+        try:
+            _run_pipeline_stage(
+                stage=stage,
+                repo_ref=repo_ref,
+                local_path=local_path,
+                version=version,
+                spec=str(resolved_spec) if resolved_spec is not None else None,
+                dry_run=dry_run,
+            )
+        except SystemExit as exc:
+            exit_code = exc.code if exc.code is not None else 1
+            if exit_code != 0:
+                resume_cmd = f"composer run --from {stage}"
+                if repo:
+                    resume_cmd += f" --repo {repo}"
+                click.echo(
+                    f"Error: {stage} failed. To resume: {resume_cmd}",
+                    err=True,
+                )
+                raise SystemExit(1) from exc
+        except Exception as exc:
+            resume_cmd = f"composer run --from {stage}"
+            if repo:
+                resume_cmd += f" --repo {repo}"
+            click.echo(
+                f"Error: {stage} failed. To resume: {resume_cmd}",
+                err=True,
+            )
+            raise SystemExit(1) from exc

--- a/tests/unit/test_cli_run.py
+++ b/tests/unit/test_cli_run.py
@@ -1,0 +1,527 @@
+"""Unit tests for the `composer run` subcommand (cli.py)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from composer.cli import _PIPELINE_STAGES, composer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_ENV = {
+    "ANTHROPIC_API_KEY": "sk-ant-test-key",
+    "GITHUB_TOKEN": "ghp-test-token",
+}
+
+
+def _make_mock_spec(tmp_path: Path) -> Path:
+    """Write a minimal spec file and return its absolute path."""
+    spec_file = tmp_path / "MVP.md"
+    spec_file.write_text("# MVP Spec\n\nA minimal spec.\n")
+    return spec_file
+
+
+# ---------------------------------------------------------------------------
+# _PIPELINE_STAGES order
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineStagesConstant:
+    def test_stages_in_correct_order(self) -> None:
+        assert _PIPELINE_STAGES == [
+            "plan-milestones",
+            "research-worker",
+            "design-worker",
+            "plan-issues",
+            "impl-worker",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# composer run --dry-run
+# ---------------------------------------------------------------------------
+
+
+class TestRunDryRun:
+    def test_dry_run_prints_headers_and_skips_all_stages(self, tmp_path: Path) -> None:
+        """--dry-run prints stage headers and [dry-run] lines but does not invoke stages."""
+        spec_file = _make_mock_spec(tmp_path)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage") as mock_stage,
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--repo", "owner/repo", "--spec", str(spec_file), "--dry-run"],
+                )
+
+        assert result.exit_code == 0, result.output
+        output = result.output
+
+        # Each stage header must appear
+        for stage in _PIPELINE_STAGES:
+            assert f"── Stage: {stage} ──" in output
+            assert f"[dry-run] would invoke {stage}" in output
+
+        # _run_pipeline_stage must NOT be called in dry-run mode
+        mock_stage.assert_not_called()
+
+    def test_dry_run_does_not_require_credentials(self, tmp_path: Path) -> None:
+        """--dry-run must not fail due to missing env vars (stages are not invoked)."""
+        # Do NOT set ANTHROPIC_API_KEY or GITHUB_TOKEN
+        with patch.dict("os.environ", {}, clear=True):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage") as mock_stage,
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--repo", "owner/repo", "--version", "MVP", "--dry-run"],
+                )
+
+        # Should succeed (no stages actually ran)
+        assert result.exit_code == 0, result.output
+        mock_stage.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# composer run: stage execution order
+# ---------------------------------------------------------------------------
+
+
+class TestRunStageOrder:
+    def test_stages_run_in_correct_order(self, tmp_path: Path) -> None:
+        """All five stages must be called in pipeline order."""
+        spec_file = _make_mock_spec(tmp_path)
+        call_order: list[str] = []
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            call_order.append(stage)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--repo", "owner/repo", "--spec", str(spec_file)],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert call_order == _PIPELINE_STAGES
+
+    def test_stage_function_receives_correct_arguments(self, tmp_path: Path) -> None:
+        """Each stage is called with repo_ref, local_path, version, and dry_run=False."""
+        spec_file = _make_mock_spec(tmp_path)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage") as mock_stage,
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--repo", "owner/repo", "--spec", str(spec_file)],
+                )
+
+        assert result.exit_code == 0, result.output
+        # Check the plan-milestones call
+        first_call_kwargs = mock_stage.call_args_list[0].kwargs
+        assert first_call_kwargs["stage"] == "plan-milestones"
+        assert first_call_kwargs["repo_ref"] == "owner/repo"
+        assert first_call_kwargs["version"] == "MVP"
+        assert first_call_kwargs["dry_run"] is False
+
+
+# ---------------------------------------------------------------------------
+# composer run --from <stage>
+# ---------------------------------------------------------------------------
+
+
+class TestRunFromStage:
+    def test_from_research_worker_skips_plan_milestones(self, tmp_path: Path) -> None:
+        """--from research-worker must skip plan-milestones and run the rest."""
+        called_stages: list[str] = []
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            called_stages.append(stage)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                        "--from",
+                        "research-worker",
+                    ],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert called_stages == [
+            "research-worker",
+            "design-worker",
+            "plan-issues",
+            "impl-worker",
+        ]
+        # plan-milestones must not appear
+        assert "plan-milestones" not in called_stages
+
+    def test_from_plan_milestones_runs_all_stages(self, tmp_path: Path) -> None:
+        """--from plan-milestones (first stage) runs all stages."""
+        called_stages: list[str] = []
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            called_stages.append(stage)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                        "--from",
+                        "plan-milestones",
+                    ],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert called_stages == _PIPELINE_STAGES
+
+    def test_from_impl_worker_runs_only_last_stage(self, tmp_path: Path) -> None:
+        """--from impl-worker must skip all earlier stages and run only impl-worker."""
+        called_stages: list[str] = []
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            called_stages.append(stage)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                        "--from",
+                        "impl-worker",
+                    ],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert called_stages == ["impl-worker"]
+
+    def test_skip_output_printed_for_skipped_stages(self, tmp_path: Path) -> None:
+        """[skip] must appear in output for each skipped stage."""
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage"),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                        "--from",
+                        "design-worker",
+                    ],
+                )
+
+        assert result.exit_code == 0, result.output
+        output = result.output
+        assert "[skip] plan-milestones" in output
+        assert "[skip] research-worker" in output
+        # design-worker and later should NOT have [skip]
+        assert "[skip] design-worker" not in output
+        assert "[skip] impl-worker" not in output
+
+
+# ---------------------------------------------------------------------------
+# composer run: invalid --from
+# ---------------------------------------------------------------------------
+
+
+class TestRunInvalidFrom:
+    def test_invalid_from_value_produces_clear_error(self, tmp_path: Path) -> None:
+        """An unrecognized --from value must fail with a clear error message."""
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                        "--from",
+                        "not-a-real-stage",
+                    ],
+                )
+
+        assert result.exit_code != 0
+        assert "not-a-real-stage" in result.output or "not-a-real-stage" in (result.output or "")
+
+    def test_invalid_from_value_lists_valid_stages(self, tmp_path: Path) -> None:
+        """Error for invalid --from must mention at least one valid stage name."""
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                        "--from",
+                        "unknown-stage",
+                    ],
+                )
+
+        combined = result.output + (result.exception and str(result.exception) or "")
+        # At least one valid stage must appear in the error output
+        assert any(stage in combined for stage in _PIPELINE_STAGES)
+
+
+# ---------------------------------------------------------------------------
+# composer run: stage failure halts pipeline and prints resume hint
+# ---------------------------------------------------------------------------
+
+
+class TestRunStageFailure:
+    def test_stage_failure_halts_pipeline(self, tmp_path: Path) -> None:
+        """If a stage raises an exception, the pipeline halts (subsequent stages not called)."""
+        called_stages: list[str] = []
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            called_stages.append(stage)
+            if stage == "research-worker":
+                raise RuntimeError("research agent failed")
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                    ],
+                )
+
+        assert result.exit_code != 0
+        # Only stages up to and including the failing stage must have been called
+        assert called_stages == ["plan-milestones", "research-worker"]
+        # design-worker and later must NOT have been called
+        assert "design-worker" not in called_stages
+
+    def test_stage_failure_prints_resume_hint(self, tmp_path: Path) -> None:
+        """A stage failure must print a message with the failing stage name and resume command."""
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            if stage == "design-worker":
+                raise RuntimeError("design agent timed out")
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                    ],
+                )
+
+        assert result.exit_code != 0
+        # The error output must name the failing stage and suggest a resume command
+        combined_output = result.output + (result.output or "")
+        assert "design-worker" in combined_output
+        assert "--from" in combined_output
+
+    def test_stage_failure_exit_code_nonzero(self, tmp_path: Path) -> None:
+        """Any stage failure must produce a non-zero exit code."""
+
+        def fake_run_stage(stage: str, **kwargs: object) -> None:
+            if stage == "plan-milestones":
+                raise Exception("something went wrong")
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--version",
+                        "MVP",
+                    ],
+                )
+
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# composer run: --version derived from --spec filename
+# ---------------------------------------------------------------------------
+
+
+class TestRunVersionInference:
+    def test_version_inferred_from_spec_filename(self, tmp_path: Path) -> None:
+        """When --spec is given without --version, version defaults to spec filename stem."""
+        spec_file = tmp_path / "calculator.md"
+        spec_file.write_text("# Calculator Spec\n")
+
+        received_versions: list[str] = []
+
+        def fake_run_stage(stage: str, version: str, **kwargs: object) -> None:
+            received_versions.append(version)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--repo", "owner/repo", "--spec", str(spec_file)],
+                )
+
+        assert result.exit_code == 0, result.output
+        # All stages received "calculator" as the version
+        assert all(v == "calculator" for v in received_versions)
+        assert len(received_versions) == len(_PIPELINE_STAGES)
+
+    def test_explicit_version_overrides_spec_stem(self, tmp_path: Path) -> None:
+        """--version overrides the version inferred from the spec filename."""
+        spec_file = tmp_path / "calculator.md"
+        spec_file.write_text("# Calculator Spec\n")
+
+        received_versions: list[str] = []
+
+        def fake_run_stage(stage: str, version: str, **kwargs: object) -> None:
+            received_versions.append(version)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))),
+                patch("composer.cli._run_pipeline_stage", side_effect=fake_run_stage),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    [
+                        "run",
+                        "--repo",
+                        "owner/repo",
+                        "--spec",
+                        str(spec_file),
+                        "--version",
+                        "MVP",
+                    ],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert all(v == "MVP" for v in received_versions)
+
+    def test_missing_version_and_spec_produces_error(self, tmp_path: Path) -> None:
+        """When neither --spec nor --version is given, the command must fail with a clear error."""
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("composer.cli._resolve_repo", return_value=("owner/repo", str(tmp_path))):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--repo", "owner/repo"],
+                )
+
+        assert result.exit_code != 0
+        # Should mention --version or --spec in the error
+        assert "--version" in result.output or "--spec" in result.output
+
+
+# ---------------------------------------------------------------------------
+# composer --help includes run
+# ---------------------------------------------------------------------------
+
+
+class TestRunInHelp:
+    def test_run_appears_in_composer_help(self) -> None:
+        """composer --help must list 'run' as a subcommand."""
+        runner = CliRunner()
+        result = runner.invoke(composer, ["--help"])
+
+        assert result.exit_code == 0
+        assert "run" in result.output
+
+    def test_run_help_shows_options(self) -> None:
+        """composer run --help must show --repo, --spec, --version, --from, --dry-run."""
+        runner = CliRunner()
+        result = runner.invoke(composer, ["run", "--help"])
+
+        assert result.exit_code == 0
+        output = result.output
+        assert "--repo" in output
+        assert "--spec" in output
+        assert "--version" in output
+        assert "--from" in output
+        assert "--dry-run" in output


### PR DESCRIPTION
Closes #200

Adds `composer run` — a single command that orchestrates the full pipeline from spec to merged PRs.

## What was added

### `composer run` subcommand (`src/composer/cli.py`)

```
composer run [--repo <target>] [--spec <path>] [--version <name>] [--from <stage>] [--dry-run]
```

- Runs all five pipeline stages in order: `plan-milestones` → `research-worker` → `design-worker` → `plan-issues` → `impl-worker`
- Each stage waits for the previous to complete before starting
- `--spec`: seeds the spec file into the target repo before `plan-milestones` runs
- `--version`: version name (defaults to spec filename stem when `--spec` is given)
- `--from <stage>`: resume from a specific stage, skipping earlier ones. Fails with a clear error on invalid values.
- `--dry-run`: prints stage headers and `[dry-run] would invoke <stage>` for each stage without executing
- On any stage failure: prints a clear error with the failing stage name and a `composer run --from <stage>` resume hint, then exits non-zero immediately

Stages are implemented by calling the existing `_run_pipeline_stage` helper which delegates to the internal `_run_*` functions — no subprocess shelling out.

### Unit tests (`tests/unit/test_cli_run.py`)

19 tests covering:
- `_PIPELINE_STAGES` order
- `--dry-run` prints headers for all stages and skips invocations
- Stages run in correct order (mocked)
- `--from` skips earlier stages and runs remaining
- Invalid `--from` value produces clear error listing valid stages
- Stage failure halts pipeline and prints resume hint
- `--version` inferred from spec filename stem
- `run` appears in `composer --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)