### PR TITLE
fix: remove Notion MCP from all worker invocations

### DIFF
--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -1447,7 +1447,6 @@ def _run_research_worker(
                 "Grep",
                 "WebSearch",
                 "WebFetch",
-                "mcp__notion__API-post-page",
             ],
             env=env,
             max_turns=100,
@@ -2793,15 +2792,7 @@ def _run_design_worker(
     env = build_subprocess_env(config)
     result = runner.run(
         prompt=prompt,
-        allowed_tools=[
-            "Bash",
-            "Read",
-            "Edit",
-            "Write",
-            "Glob",
-            "Grep",
-            "mcp__notion__API-post-page",
-        ],
+        allowed_tools=["Bash", "Read", "Edit", "Write", "Glob", "Grep"],
         env=env,
         max_turns=200,
     )
@@ -2896,13 +2887,7 @@ def _run_plan_issues(
     env = build_subprocess_env(config)
     result = runner.run(
         prompt=prompt,
-        allowed_tools=[
-            "Bash",
-            "Read",
-            "Glob",
-            "Grep",
-            "mcp__notion__API-post-page",
-        ],
+        allowed_tools=["Bash", "Read", "Glob", "Grep"],
         env=env,
         max_turns=200,
     )
@@ -3067,13 +3052,7 @@ def _run_plan_milestones(
     env = build_subprocess_env(config)
     result = runner.run(
         prompt=prompt,
-        allowed_tools=[
-            "Bash",
-            "Read",
-            "Glob",
-            "Grep",
-            "mcp__notion__API-post-page",
-        ],
+        allowed_tools=["Bash", "Read", "Glob", "Grep"],
         env=env,
         max_turns=200,
     )

--- a/src/composer/skills/design-worker.md
+++ b/src/composer/skills/design-worker.md
@@ -160,11 +160,6 @@ gh issue create \
   --milestone "<research-milestone>"
 ```
 
-Post a Notion report under "CC Autonomous Coding Sessions"
-(parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) with:
-- **Title**: `Design Session — {YYYY-MM-DD} — {repo name}`
-- **Body**: research milestone processed, design docs produced, coverage gaps, verdict
-
 ## Constraints
 
 - **No code** — design-worker creates design documents only, never touches source files
@@ -172,4 +167,4 @@ Post a Notion report under "CC Autonomous Coding Sessions"
 - **No dispatching** — design-worker does not launch sub-agents
 - **One PR per doc** — HLD gets its own PR; each LLD gets its own PR; merge before writing the next
 - **No gold-plating** — document only what research explicitly determined; don't invent scope
-- **Post session report to Notion** when done
+- Report progress: log each doc produced/merged as it happens

--- a/src/composer/skills/impl-worker.md
+++ b/src/composer/skills/impl-worker.md
@@ -143,19 +143,11 @@ When the pipeline is fully drained (no active agents, no remaining dispatchable 
      --label "pipeline"
    ```
 
-3. **Post a Notion report** under "CC Autonomous Coding Sessions"
-   (parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) using
-   `mcp__notion__API-post-page` with:
-   - **Title**: `Session Report — {YYYY-MM-DD} — {repo name}`
-   - **Body** (as Notion blocks): issues attempted, PRs merged, issues
-     failed/abandoned, newly unblocked issues for next run, and total duration
-
 ## Constraints
 
 - **Operate autonomously** — do not ask for confirmation before dispatching work
   (only ask during startup if orphaned work is detected)
 - **Fill freed module slots immediately** as agents complete — maintain maximum throughput
-- **Post session report to Notion** when the pipeline drains
 - Maximize parallelism: dispatch as many non-conflicting agents as possible
 - Respect module isolation: only one agent per module/package scope at a time
 - Serialize merges: merge one PR at a time, rebase others if needed

--- a/src/composer/skills/plan-issues.md
+++ b/src/composer/skills/plan-issues.md
@@ -193,15 +193,6 @@ gh issue create \
   --milestone "<impl-milestone>"
 ```
 
-### Step 7 — Post Notion Report
-
-Post a session report under "CC Autonomous Coding Sessions"
-(parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) using
-`mcp__notion__API-post-page` with:
-- **Title**: `Plan-Issues Session — {YYYY-MM-DD} — {repo name}`
-- **Body**: impl milestone targeted, issues filed (with titles and labels), execution order,
-  any gaps noted, final verdict
-
 ## Constraints
 
 - **GitHub issues only** — plan-issues creates GitHub issues only; never touches source files,
@@ -215,5 +206,4 @@ Post a session report under "CC Autonomous Coding Sessions"
 - **`--dry-run` prints, does not create** — if `--dry-run` is set, print all planned issues
   to stdout and stop without calling `gh issue create`
 - **Verify no circular deps** before finalizing the issue set
-- **Post session report to Notion** when done
 - **File the pipeline tracking issue** `Run impl-worker for <impl-milestone>` when done

--- a/src/composer/skills/plan-milestones.md
+++ b/src/composer/skills/plan-milestones.md
@@ -97,9 +97,6 @@ gh issue list --state closed --limit 200 --json number,title,milestone,labels
 gh issue list --state open --limit 200 --json number,title,milestone,labels
 ```
 
-Read the last 3–5 session Notion reports if available to understand what was completed
-and what gaps or follow-ups were identified.
-
 ### Step 2 — Define the Next Version Scope
 
 Use the spec's **Scope**, **Constraints**, and **Success Criteria** sections to anchor the
@@ -185,11 +182,6 @@ File the next pipeline stage issue:
 ```bash
 gh issue create --title "Run research-worker for <research milestone>" --label "pipeline" --milestone "<research milestone>"
 ```
-
-Post a Notion report under "CC Autonomous Coding Sessions"
-(parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) with:
-- **Title**: `Milestone Plan — {YYYY-MM-DD} — {repo name} — {version name}`
-- **Body**: version scope (from spec), milestones created, seed issues, next steps
 
 ## Constraints
 

--- a/src/composer/skills/research-worker.md
+++ b/src/composer/skills/research-worker.md
@@ -249,12 +249,6 @@ When the pipeline drains for the active milestone:
    gh issue create --title "Run design-worker for <milestone>" --label "pipeline" --milestone "<milestone>"
    ```
 
-3. **Post a Notion report** under "CC Autonomous Coding Sessions"
-   (parent page ID: `317bb275-6a02-803d-a59f-dc56c3527942`) using
-   `mcp__notion__API-post-page` with:
-   - **Title**: `Research Session — {YYYY-MM-DD} — {repo name}`
-   - **Body**: research completed, follow-ups created, gaps identified, remaining work
-
 ## Constraints
 
 - **Maximum 5 parallel agents** — respect this limit at all times
@@ -263,5 +257,4 @@ When the pipeline drains for the active milestone:
 - **PRs must have full descriptions** — title, summary, key findings, follow-ups spawned
 - **No infinite loops** — stop when the milestone queue is empty
 - **Triage every follow-up before dispatch** — apply rubric immediately after each merge; close failing issues with `wont-research`; remove `triage` label from passing issues
-- **Post session report to Notion** when done
 - Report progress: log each completion/merge/follow-up creation as it happens

--- a/tests/unit/test_cli_design.py
+++ b/tests/unit/test_cli_design.py
@@ -142,7 +142,7 @@ class TestRunDesignWorker:
         assert "Write" in allowed_tools
         assert "Glob" in allowed_tools
         assert "Grep" in allowed_tools
-        assert "mcp__notion__API-post-page" in allowed_tools
+        assert "mcp__notion__API-post-page" not in allowed_tools
         # design-worker must NOT dispatch sub-agents, so no agent tool
         assert "mcp__claude_code__execute" not in allowed_tools
 
@@ -281,7 +281,7 @@ class TestRunPlanIssues:
         assert "Read" in allowed_tools
         assert "Glob" in allowed_tools
         assert "Grep" in allowed_tools
-        assert "mcp__notion__API-post-page" in allowed_tools
+        assert "mcp__notion__API-post-page" not in allowed_tools
         # plan-issues only reads files and calls gh; must NOT use Write/Edit
         assert "Write" not in allowed_tools
         assert "Edit" not in allowed_tools


### PR DESCRIPTION
## Summary
- Removes `mcp__notion__API-post-page` from the `allowed_tools` list at all 4 orchestrator `runner.run()` call sites (research-worker, design-worker, plan-issues, plan-milestones)
- The tool was listed but MCP was suppressed via `--strict-mcp-config --mcp-config '{}'`, causing silent hangs when Claude attempted to call it
- Removes Notion posting instructions and constraints from all 5 skill files
- Updates 2 test assertions in `test_cli_design.py` from `in` to `not in`

## Test plan
- [ ] All 441 unit tests pass
- [ ] `ruff check` and `ruff format --check` clean

Closes #209