### PR TITLE
feat: add model config field, default claude-opus-4-6

### DIFF
--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -1073,6 +1073,7 @@ def _score_triage_issue(
         env=env,
         max_turns=5,
         timeout_seconds=config.agent_timeout_minutes * 60,
+        model=config.model,
     )
 
     if result.is_error:
@@ -1240,6 +1241,7 @@ def _classify_blocking_issues(
             env=env,
             max_turns=5,
             timeout_seconds=config.agent_timeout_minutes * 60,
+            model=config.model,
         )
 
         if result.is_error:
@@ -1453,6 +1455,7 @@ def _run_research_worker(
             env=env,
             max_turns=100,
             timeout_seconds=config.agent_timeout_minutes * 60,
+            model=config.model,
         )
 
         # ------------------------------------------------------------------
@@ -2357,6 +2360,7 @@ def _dispatch_impl_agent(
         env=env,
         max_turns=max_turns,
         timeout_seconds=config.agent_timeout_minutes * 60,
+        model=config.model,
     )
     return issue, branch, worktree_path, result
 
@@ -2800,6 +2804,7 @@ def _run_design_worker(
         env=env,
         max_turns=200,
         timeout_seconds=config.agent_timeout_minutes * 60,
+        model=config.model,
     )
 
     logger.log_conductor_event(
@@ -2896,6 +2901,7 @@ def _run_plan_issues(
         env=env,
         max_turns=200,
         timeout_seconds=config.agent_timeout_minutes * 60,
+        model=config.model,
     )
 
     logger.log_conductor_event(
@@ -3062,6 +3068,7 @@ def _run_plan_milestones(
         env=env,
         max_turns=200,
         timeout_seconds=config.agent_timeout_minutes * 60,
+        model=config.model,
     )
 
     logger.log_conductor_event(

--- a/src/composer/config.py
+++ b/src/composer/config.py
@@ -105,6 +105,12 @@ class Config(BaseSettings):
         description="Directory for session checkpoints",
     )
 
+    # --- Model ---
+    model: str = Field(
+        default="claude-opus-4-6",
+        description="Claude model ID passed to claude -p via --model",
+    )
+
     # --- Git / GitHub ---
     default_branch: str = Field(
         default="main",

--- a/src/composer/runner.py
+++ b/src/composer/runner.py
@@ -130,6 +130,7 @@ def run(
     mcp_config: Path | None = None,
     verbose: bool = True,
     timeout_seconds: float | None = None,
+    model: str | None = None,
 ) -> RunResult:
     """Invoke ``claude -p`` as a subprocess and return a structured result.
 
@@ -166,6 +167,9 @@ def run(
         running after this many seconds it receives SIGTERM; if it does not exit
         within 5 seconds it is SIGKILLed. The returned RunResult will have
         ``subtype="timeout"`` and ``is_error=True``. None means no limit.
+    model:
+        Claude model ID to pass via ``--model``. When None, claude uses its
+        default. Typically sourced from ``config.model``.
 
     Returns
     -------
@@ -188,6 +192,7 @@ def run(
         max_turns=max_turns,
         append_system_prompt_file=append_system_prompt_file,
         mcp_config=mcp_config,
+        model=model,
     )
 
     if dry_run:
@@ -256,9 +261,14 @@ def _assemble_command(
     max_turns: int,
     append_system_prompt_file: Path | None,
     mcp_config: Path | None,
+    model: str | None = None,
 ) -> list[str]:
     """Assemble the ``claude`` command list."""
     cmd: list[str] = ["claude", "-p", prompt]
+
+    # Model selection
+    if model:
+        cmd += ["--model", model]
 
     # Output format — always stream-json
     cmd += ["--output-format", "stream-json"]


### PR DESCRIPTION
## Summary
- Adds `model: str = Field(default="claude-opus-4-6", ...)` to `Config` in `config.py`
- Adds `model: str | None = None` parameter to `runner.run()` and `_assemble_command()`; injects `--model <model>` into the `claude -p` command when set
- Wires `model=config.model` at all 7 `runner.run()` call sites in `cli.py`

The `COMPOSER_MODEL` (or `CONDUCTOR_MODEL`) env var can override the default.

## Test plan
- [ ] All 441 unit tests pass
- [ ] `ruff check` and `ruff format --check` clean

Closes #212