### PR TITLE
fix: rename CONDUCTOR_ env var prefix to COMPOSER_

### DIFF
--- a/src/composer/config.py
+++ b/src/composer/config.py
@@ -42,14 +42,14 @@ class Config(BaseSettings):
     """Runtime configuration for composer commands."""
 
     model_config = SettingsConfigDict(
-        env_prefix="CONDUCTOR_",
+        env_prefix="COMPOSER_",
         env_file=".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
         populate_by_name=True,
     )
 
-    # --- Required credentials (no CONDUCTOR_ prefix) ---
+    # --- Required credentials (no COMPOSER_ prefix) ---
     anthropic_api_key: str = Field(
         validation_alias=AliasChoices("ANTHROPIC_API_KEY", "anthropic_api_key"),
         description="Anthropic API key",
@@ -151,7 +151,7 @@ class Config(BaseSettings):
     max_orphaned_issues: int = Field(
         default=5,
         ge=0,
-        validation_alias=AliasChoices("CONDUCTOR_MAX_ORPHANED_ISSUES", "max_orphaned_issues"),
+        validation_alias=AliasChoices("COMPOSER_MAX_ORPHANED_ISSUES", "max_orphaned_issues"),
         description="Maximum number of orphaned in-progress issues before health check fails",
     )
 
@@ -248,14 +248,14 @@ def _reraise_validation_error(exc: Exception) -> None:
 
 def _field_to_env_var(field_name: str) -> str:
     """Convert a Config field name to its corresponding environment variable name."""
-    # Fields with custom aliases (no CONDUCTOR_ prefix)
+    # Fields with custom aliases (no COMPOSER_ prefix)
     no_prefix = {
         "anthropic_api_key": "ANTHROPIC_API_KEY",
         "github_token": "GITHUB_TOKEN",
     }
     if field_name in no_prefix:
         return no_prefix[field_name]
-    return "CONDUCTOR_" + field_name.upper()
+    return "COMPOSER_" + field_name.upper()
 
 
 # ---------------------------------------------------------------------------

--- a/src/composer/health.py
+++ b/src/composer/health.py
@@ -202,7 +202,7 @@ def _check_default_branch(config: Config) -> CheckResult:
         status="warn",
         message=f"Mismatch: config={configured_branch}, repo={actual_branch}",
         remediation=(
-            f"Set CONDUCTOR_DEFAULT_BRANCH={actual_branch} or update config to match "
+            f"Set COMPOSER_DEFAULT_BRANCH={actual_branch} or update config to match "
             f"the repo's default branch ({actual_branch})."
         ),
     )

--- a/src/composer/logger.py
+++ b/src/composer/logger.py
@@ -49,7 +49,7 @@ from pathlib import Path
 
 #: All valid conductor event_type values. Callers should pass one of these strings
 #: to log_conductor_event to keep the log parseable.
-CONDUCTOR_EVENT_TYPES: frozenset[str] = frozenset(
+COMPOSER_EVENT_TYPES: frozenset[str] = frozenset(
     {
         "stage_start",
         "issue_claimed",
@@ -324,7 +324,7 @@ def log_conductor_event(
     The conductor log is single-writer (only the orchestrator process writes to
     its own run file); no file locking is applied.
 
-    Valid event types (see ``CONDUCTOR_EVENT_TYPES``):
+    Valid event types (see ``COMPOSER_EVENT_TYPES``):
       stage_start, issue_claimed, agent_dispatched, agent_completed,
       pr_created, ci_checked, pr_merged, backoff_enter, backoff_exit,
       human_escalate, checkpoint_write, stage_complete.
@@ -333,7 +333,7 @@ def log_conductor_event(
         run_id:     UUID of the conductor run; used as the filename.
         phase:      Current pipeline phase (e.g. ``init``, ``claim``,
                     ``dispatch``, ``ci_check``, ``merge``, ``backoff``).
-        event_type: Discriminator string; one of ``CONDUCTOR_EVENT_TYPES``.
+        event_type: Discriminator string; one of ``COMPOSER_EVENT_TYPES``.
         payload:    Event-type-specific dict; must be JSON-serialisable.
         log_dir:    Resolved log root directory.
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -85,13 +85,13 @@ def test_config_paths_default_to_home_composer(monkeypatch: pytest.MonkeyPatch) 
 
 
 # ---------------------------------------------------------------------------
-# Config loading — CONDUCTOR_* overrides
+# Config loading — COMPOSER_* overrides
 # ---------------------------------------------------------------------------
 
 
 def test_conductor_max_concurrency_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    """CONDUCTOR_MAX_CONCURRENCY overrides the default."""
-    for key, val in make_env(CONDUCTOR_MAX_CONCURRENCY="5").items():
+    """COMPOSER_MAX_CONCURRENCY overrides the default."""
+    for key, val in make_env(COMPOSER_MAX_CONCURRENCY="5").items():
         monkeypatch.setenv(key, val)
 
     config = Config()
@@ -99,8 +99,8 @@ def test_conductor_max_concurrency_env_var(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_conductor_max_concurrency_custom_value(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A custom CONDUCTOR_MAX_CONCURRENCY value is reflected in the config."""
-    for key, val in make_env(CONDUCTOR_MAX_CONCURRENCY="8").items():
+    """A custom COMPOSER_MAX_CONCURRENCY value is reflected in the config."""
+    for key, val in make_env(COMPOSER_MAX_CONCURRENCY="8").items():
         monkeypatch.setenv(key, val)
 
     config = Config()
@@ -108,8 +108,8 @@ def test_conductor_max_concurrency_custom_value(monkeypatch: pytest.MonkeyPatch)
 
 
 def test_conductor_subscription_tier_max(monkeypatch: pytest.MonkeyPatch) -> None:
-    """CONDUCTOR_SUBSCRIPTION_TIER=max is accepted."""
-    for key, val in make_env(CONDUCTOR_SUBSCRIPTION_TIER="max").items():
+    """COMPOSER_SUBSCRIPTION_TIER=max is accepted."""
+    for key, val in make_env(COMPOSER_SUBSCRIPTION_TIER="max").items():
         monkeypatch.setenv(key, val)
 
     config = Config()
@@ -117,8 +117,8 @@ def test_conductor_subscription_tier_max(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_conductor_subscription_tier_max20x(monkeypatch: pytest.MonkeyPatch) -> None:
-    """CONDUCTOR_SUBSCRIPTION_TIER=max20x is accepted."""
-    for key, val in make_env(CONDUCTOR_SUBSCRIPTION_TIER="max20x").items():
+    """COMPOSER_SUBSCRIPTION_TIER=max20x is accepted."""
+    for key, val in make_env(COMPOSER_SUBSCRIPTION_TIER="max20x").items():
         monkeypatch.setenv(key, val)
 
     config = Config()
@@ -161,9 +161,9 @@ def test_missing_github_token_raises_configuration_error(
 def test_invalid_subscription_tier_raises_configuration_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An unrecognised CONDUCTOR_SUBSCRIPTION_TIER raises ConfigurationError."""
+    """An unrecognised COMPOSER_SUBSCRIPTION_TIER raises ConfigurationError."""
     monkeypatch.delenv("CLAUDECODE", raising=False)
-    for key, val in make_env(CONDUCTOR_SUBSCRIPTION_TIER="enterprise").items():
+    for key, val in make_env(COMPOSER_SUBSCRIPTION_TIER="enterprise").items():
         monkeypatch.setenv(key, val)
 
     with pytest.raises(ConfigurationError):
@@ -173,9 +173,9 @@ def test_invalid_subscription_tier_raises_configuration_error(
 def test_invalid_max_budget_type_raises_configuration_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A non-numeric CONDUCTOR_MAX_BUDGET_USD raises ConfigurationError."""
+    """A non-numeric COMPOSER_MAX_BUDGET_USD raises ConfigurationError."""
     monkeypatch.delenv("CLAUDECODE", raising=False)
-    for key, val in make_env(CONDUCTOR_MAX_BUDGET_USD="not-a-number").items():
+    for key, val in make_env(COMPOSER_MAX_BUDGET_USD="not-a-number").items():
         monkeypatch.setenv(key, val)
 
     with pytest.raises(ConfigurationError):
@@ -244,7 +244,7 @@ def test_build_subprocess_env_does_not_include_parent_env_secrets() -> None:
             "AWS_SECRET_ACCESS_KEY": "top-secret",
             "DATABASE_URL": "postgres://user:pass@host/db",
             "GOOGLE_API_KEY": "google-key",
-            "CONDUCTOR_SOME_INTERNAL": "internal-value",
+            "COMPOSER_SOME_INTERNAL": "internal-value",
             "SSH_AUTH_SOCK": "/tmp/ssh-agent.sock",
         },
     ):
@@ -253,7 +253,7 @@ def test_build_subprocess_env_does_not_include_parent_env_secrets() -> None:
     assert "AWS_SECRET_ACCESS_KEY" not in env
     assert "DATABASE_URL" not in env
     assert "GOOGLE_API_KEY" not in env
-    assert "CONDUCTOR_SOME_INTERNAL" not in env
+    assert "COMPOSER_SOME_INTERNAL" not in env
     assert "SSH_AUTH_SOCK" not in env
 
 
@@ -347,7 +347,7 @@ def test_build_subprocess_env_includes_anthropic_api_key() -> None:
 
 def test_sessions_dir_derived_from_log_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     """sessions_dir is log_dir.expanduser() / 'sessions'."""
-    for key, val in make_env(CONDUCTOR_LOG_DIR="/tmp/test-logs").items():
+    for key, val in make_env(COMPOSER_LOG_DIR="/tmp/test-logs").items():
         monkeypatch.setenv(key, val)
 
     config = Config()
@@ -356,7 +356,7 @@ def test_sessions_dir_derived_from_log_dir(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_cost_ledger_derived_from_log_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     """cost_ledger is log_dir.expanduser() / 'cost.jsonl'."""
-    for key, val in make_env(CONDUCTOR_LOG_DIR="/tmp/test-logs").items():
+    for key, val in make_env(COMPOSER_LOG_DIR="/tmp/test-logs").items():
         monkeypatch.setenv(key, val)
 
     config = Config()

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from composer.logger import (
-    CONDUCTOR_EVENT_TYPES,
+    COMPOSER_EVENT_TYPES,
     LogContext,
     _append_locked,
     _estimate_cost_usd,
@@ -666,12 +666,12 @@ def test_log_conductor_event_appends_multiple_events(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# CONDUCTOR_EVENT_TYPES constant
+# COMPOSER_EVENT_TYPES constant
 # ---------------------------------------------------------------------------
 
 
 def test_conductor_event_types_contains_all_11() -> None:
-    """CONDUCTOR_EVENT_TYPES contains exactly the 11 documented event types."""
+    """COMPOSER_EVENT_TYPES contains exactly the 11 documented event types."""
     expected = {
         "stage_start",
         "issue_claimed",
@@ -686,4 +686,4 @@ def test_conductor_event_types_contains_all_11() -> None:
         "checkpoint_write",
         "stage_complete",
     }
-    assert CONDUCTOR_EVENT_TYPES == expected
+    assert COMPOSER_EVENT_TYPES == expected


### PR DESCRIPTION
## Summary
- Renames pydantic-settings `env_prefix` from `"CONDUCTOR_"` to `"COMPOSER_"` in `config.py`
- Renames `CONDUCTOR_MAX_ORPHANED_ISSUES` alias → `COMPOSER_MAX_ORPHANED_ISSUES`
- Renames `CONDUCTOR_EVENT_TYPES` constant → `COMPOSER_EVENT_TYPES` in `logger.py`
- Updates the branch-mismatch remediation message in `health.py`
- Updates all test fixtures in `test_config.py` and `test_logger.py`

After this change the canonical env var names are `COMPOSER_*` (e.g. `COMPOSER_MODEL`, `COMPOSER_MAX_BUDGET_USD`). Any `.env` files using the old `CONDUCTOR_` prefix should be updated.

## Test plan
- [ ] All 441 unit tests pass
- [ ] `ruff check` and `ruff format --check` clean

Closes #213