### PR TITLE
fix: exempt current process from orchestrator lock check

### DIFF
--- a/src/composer/health.py
+++ b/src/composer/health.py
@@ -558,6 +558,13 @@ def _check_orchestrator_lock(config: Config) -> CheckResult:
             remediation=f"Inspect or remove: {lock_path}",
         )
 
+    if pid == os.getpid():
+        return CheckResult(
+            name="Single orchestrator guard",
+            status="pass",
+            message="Orchestrator lock is held by the current process.",
+        )
+
     try:
         os.kill(pid, 0)
         # No exception — PID is alive


### PR DESCRIPTION
## Problem

`_check_orchestrator_lock()` in `health.py` called `os.kill(pid, 0)` without checking if `pid == os.getpid()`. When the orchestrator acquires the lock (e.g. PID 93741) and then runs the research-worker health check mid-run, it finds its own lock and incorrectly declares:

```
✗ FATAL: Single orchestrator guard
   Fix: Another orchestrator is running (PID 93741, started ...). Stop it before starting a new run.
```

## Fix

Add a self-exemption before the `os.kill` call: if the lock PID matches the current process, return `pass` immediately.

```python
if pid == os.getpid():
    return CheckResult(
        name="Single orchestrator guard",
        status="pass",
        message="Orchestrator lock is held by the current process.",
    )
```

## Testing

441 unit tests pass, lint clean.

Closes #147