### PR TITLE
fix: halt pipeline when plan-milestones fails

### DIFF
--- a/src/composer/cli.py
+++ b/src/composer/cli.py
@@ -3120,6 +3120,7 @@ def _run_plan_milestones(
         )
         if result.stderr:
             click.echo(f"stderr:\n{result.stderr[:2000]}", err=True)
+        raise SystemExit(1)
     else:
         click.echo(f"Plan-milestones complete for version '{version}'.")
 


### PR DESCRIPTION
## Summary

- `_run_plan_milestones` previously printed the error then returned normally, letting `research-worker` run against an empty milestone (0 issues) and immediately fire the completion gate
- Adds `raise SystemExit(1)` after logging the error so the `run` command catches it, prints the resume hint, and stops

## Root cause

`missing_result_event` from `plan-milestones` (spec not found in remote repo) was non-fatal — the function returned, research-worker found 0 open issues, called `_run_completion_gate`, declared "complete", and advanced the pipeline to design-worker.

## Behaviour after fix

```
── Stage: plan-milestones ──
Plan-milestones completed with error: missing_result_event / None
Error: plan-milestones failed. To resume: composer run --from plan-milestones --repo calculator-cli
```

Pipeline stops. User must fix the underlying cause (e.g., seed the spec with `--spec`) before resuming.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)