### PR TITLE
feat(beads): add bead files module for atomic orchestration state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ One agent per module at a time. Each agent may only modify files within its assi
 
 | Module | Scope |
 |--------|-------|
+| `beads` | `src/brimstone/beads.py`, `~/.brimstone/beads/` |
 | `config` | `src/brimstone/config.py` |
 | `runner` | `src/brimstone/runner.py`, `src/brimstone/session.py` |
 | `health` | `src/brimstone/health.py` |

--- a/src/brimstone/beads.py
+++ b/src/brimstone/beads.py
@@ -1,0 +1,389 @@
+"""Bead files — atomic JSON state for brimstone orchestration.
+
+Replaces checkpoint.json for issue/PR lifecycle tracking. Three bead types:
+  - WorkBead:    issue lifecycle (claimed → pr_open → merge_ready → closed)
+  - PRBead:      PR + feedback triage state
+  - MergeQueue:  sequential merge ordering (replaces inline gh pr merge calls)
+
+Beads are stored under ~/.brimstone/beads/<owner>/<repo>/:
+  work/<issue_number>.json
+  prs/pr-<pr_number>.json
+  merge-queue.json
+
+All writes use write-to-.tmp + os.replace (atomic on POSIX).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Schema version
+# ---------------------------------------------------------------------------
+
+BEAD_SCHEMA_VERSION: int = 1
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class BeadError(Exception):
+    """Base exception for bead errors."""
+
+
+class BeadCorruptError(BeadError):
+    """Raised when a bead file cannot be parsed as JSON."""
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FeedbackItem:
+    """A single review comment or CI feedback item triaged by an agent."""
+
+    comment_id: str
+    author: str
+    is_bot: bool
+    triage: str  # "pending" | "fix_now" | "filed_issue" | "skipped"
+    filed_issue: int | None = None
+    triage_reason: str | None = None
+
+
+@dataclass
+class WorkBead:
+    """Issue lifecycle state — one file per issue."""
+
+    v: int
+    issue_number: int
+    title: str
+    milestone: str
+    stage: str  # "research" | "design" | "impl"
+    module: str
+    priority: str  # "P0"–"P4"
+    state: str  # "open" | "claimed" | "pr_open" | "merge_ready" | "closed" | "abandoned"
+    branch: str
+    pr_id: str | None = None  # "pr-187", links to PRBead file
+    retry_count: int = 0
+    claimed_at: str | None = None  # ISO UTC
+    closed_at: str | None = None
+
+
+@dataclass
+class PRBead:
+    """PR + feedback triage state — one file per PR."""
+
+    v: int
+    pr_number: int
+    issue_number: int
+    branch: str
+    state: str  # "open"|"ci_running"|"ci_failing"|"reviewing"|"conflict"|"merge_ready"|"merged"
+    ci_state: str | None = None
+    conflict_state: str | None = None
+    fix_attempts: int = 0
+    feedback: list[FeedbackItem] = field(default_factory=list)
+    created_at: str | None = None
+    merged_at: str | None = None
+
+
+@dataclass
+class MergeQueueEntry:
+    """A single entry in the merge queue."""
+
+    pr_number: int
+    issue_number: int
+    branch: str
+    enqueued_at: str
+
+
+@dataclass
+class MergeQueue:
+    """Sequential merge ordering for PRs that have passed CI + review."""
+
+    v: int
+    queue: list[MergeQueueEntry] = field(default_factory=list)
+    updated_at: str = ""
+
+
+# ---------------------------------------------------------------------------
+# BeadStore
+# ---------------------------------------------------------------------------
+
+
+class BeadStore:
+    """Read/write interface for bead files.
+
+    All writes are atomic: data is written to a .tmp sibling then os.replace()d
+    over the target. On POSIX this guarantees no reader sees a partial write.
+
+    Args:
+        beads_dir:        Root directory for this repo's bead files.
+        state_repo_path:  Optional path to a cloned ``brimstone-state`` git repo.
+                          When set, :meth:`flush` commits and pushes dirty beads.
+    """
+
+    def __init__(self, beads_dir: Path, state_repo_path: Path | None = None) -> None:
+        self._beads_dir = beads_dir
+        self._state_repo_path = state_repo_path
+        # Ensure subdirs exist
+        (beads_dir / "work").mkdir(parents=True, exist_ok=True)
+        (beads_dir / "prs").mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Paths
+    # ------------------------------------------------------------------
+
+    def _work_path(self, issue_number: int) -> Path:
+        return self._beads_dir / "work" / f"{issue_number}.json"
+
+    def _pr_path(self, pr_number: int) -> Path:
+        return self._beads_dir / "prs" / f"pr-{pr_number}.json"
+
+    def _merge_queue_path(self) -> Path:
+        return self._beads_dir / "merge-queue.json"
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def read_work_bead(self, issue_number: int) -> WorkBead | None:
+        """Return the WorkBead for *issue_number*, or None if absent."""
+        path = self._work_path(issue_number)
+        if not path.exists():
+            return None
+        return _load_work_bead(path)
+
+    def read_pr_bead(self, pr_number: int) -> PRBead | None:
+        """Return the PRBead for *pr_number*, or None if absent."""
+        path = self._pr_path(pr_number)
+        if not path.exists():
+            return None
+        return _load_pr_bead(path)
+
+    def read_merge_queue(self) -> MergeQueue:
+        """Return the MergeQueue, or an empty queue if the file is absent."""
+        path = self._merge_queue_path()
+        if not path.exists():
+            return MergeQueue(v=BEAD_SCHEMA_VERSION)
+        return _load_merge_queue(path)
+
+    # ------------------------------------------------------------------
+    # Lists
+    # ------------------------------------------------------------------
+
+    def list_work_beads(self, state: str | None = None) -> list[WorkBead]:
+        """Return all WorkBeads, optionally filtered by *state*."""
+        work_dir = self._beads_dir / "work"
+        results: list[WorkBead] = []
+        for p in sorted(work_dir.glob("*.json")):
+            try:
+                bead = _load_work_bead(p)
+            except BeadCorruptError:
+                continue
+            if state is None or bead.state == state:
+                results.append(bead)
+        return results
+
+    def list_pr_beads(self, state: str | None = None) -> list[PRBead]:
+        """Return all PRBeads, optionally filtered by *state*."""
+        prs_dir = self._beads_dir / "prs"
+        results: list[PRBead] = []
+        for p in sorted(prs_dir.glob("pr-*.json")):
+            try:
+                bead = _load_pr_bead(p)
+            except BeadCorruptError:
+                continue
+            if state is None or bead.state == state:
+                results.append(bead)
+        return results
+
+    # ------------------------------------------------------------------
+    # Writes (atomic)
+    # ------------------------------------------------------------------
+
+    def write_work_bead(self, bead: WorkBead) -> None:
+        """Atomically write *bead* to disk."""
+        path = self._work_path(bead.issue_number)
+        _atomic_write(path, _work_bead_to_dict(bead))
+
+    def write_pr_bead(self, bead: PRBead) -> None:
+        """Atomically write *bead* to disk."""
+        path = self._pr_path(bead.pr_number)
+        _atomic_write(path, _pr_bead_to_dict(bead))
+
+    def write_merge_queue(self, queue: MergeQueue) -> None:
+        """Atomically write the merge queue to disk."""
+        path = self._merge_queue_path()
+        _atomic_write(path, _merge_queue_to_dict(queue))
+
+    def delete_work_bead(self, issue_number: int) -> None:
+        """Delete the WorkBead for *issue_number* if it exists."""
+        path = self._work_path(issue_number)
+        if path.exists():
+            path.unlink()
+
+    # ------------------------------------------------------------------
+    # Flush to state repo
+    # ------------------------------------------------------------------
+
+    def flush(self, message: str) -> None:
+        """Commit and push dirty bead files to the state repo.
+
+        No-op when ``state_repo_path`` is None or the working tree is clean.
+
+        Args:
+            message: Git commit message.
+        """
+        if self._state_repo_path is None:
+            return
+        repo = self._state_repo_path
+        if not (repo / ".git").exists():
+            return
+        # Stage all changes
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        if not result.stdout.strip():
+            return  # nothing to commit
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+        subprocess.run(["git", "commit", "-m", message], cwd=repo, check=True)
+        subprocess.run(["git", "push"], cwd=repo, check=True)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def make_bead_store(config: Any, repo_slug: str) -> BeadStore:
+    """Create a BeadStore for the given repo slug.
+
+    The bead directory is: ``config.beads_dir / <owner> / <repo>``.
+
+    If ``config.state_repo`` is set, the state repo is cloned to
+    ``config.state_repo_dir / <owner>-<repo>`` (if not already present).
+
+    Args:
+        config:    A Config instance with ``beads_dir``, ``state_repo``, and
+                   ``state_repo_dir`` fields.
+        repo_slug: GitHub repo in ``"owner/repo"`` format.
+    """
+    beads_dir = config.beads_dir.expanduser() / repo_slug.replace("/", os.sep)
+    state_repo_path = None
+    if config.state_repo:
+        state_repo_path = config.state_repo_dir.expanduser() / config.state_repo.replace("/", "-")
+        if not (state_repo_path / ".git").exists():
+            state_repo_path.mkdir(parents=True, exist_ok=True)
+            subprocess.run(
+                ["gh", "repo", "clone", config.state_repo, str(state_repo_path)],
+                check=True,
+            )
+    return BeadStore(beads_dir=beads_dir, state_repo_path=state_repo_path)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write *data* as JSON to *path* via a .tmp sibling (atomic on POSIX)."""
+    tmp_path = path.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _load_json(path: Path) -> dict:
+    """Read and parse a JSON bead file, raising BeadCorruptError on failure."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise BeadCorruptError(f"Bead file corrupt: {path}") from exc
+
+
+def _load_work_bead(path: Path) -> WorkBead:
+    data = _load_json(path)
+    return WorkBead(
+        v=data.get("v", BEAD_SCHEMA_VERSION),
+        issue_number=data["issue_number"],
+        title=data.get("title", ""),
+        milestone=data.get("milestone", ""),
+        stage=data.get("stage", ""),
+        module=data.get("module", ""),
+        priority=data.get("priority", ""),
+        state=data.get("state", "open"),
+        branch=data.get("branch", ""),
+        pr_id=data.get("pr_id"),
+        retry_count=data.get("retry_count", 0),
+        claimed_at=data.get("claimed_at"),
+        closed_at=data.get("closed_at"),
+    )
+
+
+def _load_pr_bead(path: Path) -> PRBead:
+    data = _load_json(path)
+    feedback = [
+        FeedbackItem(
+            comment_id=f.get("comment_id", ""),
+            author=f.get("author", ""),
+            is_bot=f.get("is_bot", False),
+            triage=f.get("triage", "pending"),
+            filed_issue=f.get("filed_issue"),
+            triage_reason=f.get("triage_reason"),
+        )
+        for f in data.get("feedback", [])
+    ]
+    return PRBead(
+        v=data.get("v", BEAD_SCHEMA_VERSION),
+        pr_number=data["pr_number"],
+        issue_number=data.get("issue_number", 0),
+        branch=data.get("branch", ""),
+        state=data.get("state", "open"),
+        ci_state=data.get("ci_state"),
+        conflict_state=data.get("conflict_state"),
+        fix_attempts=data.get("fix_attempts", 0),
+        feedback=feedback,
+        created_at=data.get("created_at"),
+        merged_at=data.get("merged_at"),
+    )
+
+
+def _load_merge_queue(path: Path) -> MergeQueue:
+    data = _load_json(path)
+    entries = [
+        MergeQueueEntry(
+            pr_number=e["pr_number"],
+            issue_number=e.get("issue_number", 0),
+            branch=e.get("branch", ""),
+            enqueued_at=e.get("enqueued_at", ""),
+        )
+        for e in data.get("queue", [])
+    ]
+    return MergeQueue(
+        v=data.get("v", BEAD_SCHEMA_VERSION),
+        queue=entries,
+        updated_at=data.get("updated_at", ""),
+    )
+
+
+def _work_bead_to_dict(bead: WorkBead) -> dict:
+    return asdict(bead)
+
+
+def _pr_bead_to_dict(bead: PRBead) -> dict:
+    return asdict(bead)
+
+
+def _merge_queue_to_dict(queue: MergeQueue) -> dict:
+    return asdict(queue)

--- a/src/brimstone/config.py
+++ b/src/brimstone/config.py
@@ -119,7 +119,19 @@ class Config(BaseSettings):
     # --- Model ---
     model: str = Field(
         default="claude-sonnet-4-6",
-        description="Claude model ID passed to claude -p via --model",
+        description="Claude model ID for impl agents (default: claude-sonnet-4-6)",
+    )
+    research_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="Claude model ID for research agents (default: claude-haiku-4-5-20251001)",
+    )
+    design_model: str = Field(
+        default="claude-sonnet-4-6",
+        description="Claude model ID for design agents (default: claude-sonnet-4-6)",
+    )
+    scope_model: str = Field(
+        default="claude-haiku-4-5-20251001",
+        description="Claude model ID for scope/plan-issues agents (default: haiku)",
     )
 
     # --- Git / GitHub ---
@@ -156,6 +168,20 @@ class Config(BaseSettings):
             "Version name override for plan-milestones spec seeding. "
             "When None, the version is inferred from the spec filename stem."
         ),
+    )
+
+    # --- Bead storage ---
+    beads_dir: Path = Field(
+        default=Path("~/.brimstone/beads"),
+        description="Local bead storage root",
+    )
+    state_repo: str | None = Field(
+        default=None,
+        description="Optional 'owner/repo' for portable state (git-backed bead sync)",
+    )
+    state_repo_dir: Path = Field(
+        default=Path("~/.brimstone/state-repos"),
+        description="Clone directory for state repos",
     )
 
     # --- Health checks ---

--- a/tests/unit/test_beads.py
+++ b/tests/unit/test_beads.py
@@ -1,0 +1,357 @@
+"""Unit tests for src/brimstone/beads.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from brimstone.beads import (
+    BEAD_SCHEMA_VERSION,
+    BeadCorruptError,
+    BeadStore,
+    FeedbackItem,
+    MergeQueue,
+    MergeQueueEntry,
+    PRBead,
+    WorkBead,
+    make_bead_store,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> BeadStore:
+    return BeadStore(beads_dir=tmp_path / "beads")
+
+
+def _make_work_bead(issue_number: int = 42, state: str = "claimed") -> WorkBead:
+    return WorkBead(
+        v=BEAD_SCHEMA_VERSION,
+        issue_number=issue_number,
+        title="Test issue",
+        milestone="v1",
+        stage="impl",
+        module="cli",
+        priority="P2",
+        state=state,
+        branch=f"{issue_number}-test-slug",
+        pr_id=None,
+        retry_count=0,
+        claimed_at="2026-03-04T10:00:00+00:00",
+        closed_at=None,
+    )
+
+
+def _make_pr_bead(pr_number: int = 187, issue_number: int = 42, state: str = "open") -> PRBead:
+    return PRBead(
+        v=BEAD_SCHEMA_VERSION,
+        pr_number=pr_number,
+        issue_number=issue_number,
+        branch="42-test-slug",
+        state=state,
+        ci_state=None,
+        conflict_state=None,
+        fix_attempts=0,
+        feedback=[],
+        created_at="2026-03-04T10:05:00+00:00",
+        merged_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# WorkBead round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestWorkBeadRoundTrip:
+    def test_write_and_read(self, store: BeadStore) -> None:
+        bead = _make_work_bead()
+        store.write_work_bead(bead)
+        loaded = store.read_work_bead(42)
+        assert loaded is not None
+        assert loaded.issue_number == 42
+        assert loaded.state == "claimed"
+        assert loaded.branch == "42-test-slug"
+        assert loaded.claimed_at == "2026-03-04T10:00:00+00:00"
+
+    def test_read_absent_returns_none(self, store: BeadStore) -> None:
+        assert store.read_work_bead(999) is None
+
+    def test_overwrite_updates_state(self, store: BeadStore) -> None:
+        bead = _make_work_bead(state="claimed")
+        store.write_work_bead(bead)
+        bead.state = "pr_open"
+        store.write_work_bead(bead)
+        loaded = store.read_work_bead(42)
+        assert loaded is not None
+        assert loaded.state == "pr_open"
+
+
+# ---------------------------------------------------------------------------
+# PRBead round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPRBeadRoundTrip:
+    def test_write_and_read(self, store: BeadStore) -> None:
+        bead = _make_pr_bead()
+        store.write_pr_bead(bead)
+        loaded = store.read_pr_bead(187)
+        assert loaded is not None
+        assert loaded.pr_number == 187
+        assert loaded.issue_number == 42
+        assert loaded.state == "open"
+
+    def test_read_absent_returns_none(self, store: BeadStore) -> None:
+        assert store.read_pr_bead(999) is None
+
+    def test_feedback_round_trip(self, store: BeadStore) -> None:
+        item = FeedbackItem(
+            comment_id="c-1",
+            author="octocat",
+            is_bot=False,
+            triage="fix_now",
+            filed_issue=None,
+            triage_reason="style nit",
+        )
+        bead = _make_pr_bead()
+        bead.feedback = [item]
+        store.write_pr_bead(bead)
+        loaded = store.read_pr_bead(187)
+        assert loaded is not None
+        assert len(loaded.feedback) == 1
+        assert loaded.feedback[0].comment_id == "c-1"
+        assert loaded.feedback[0].triage == "fix_now"
+
+
+# ---------------------------------------------------------------------------
+# MergeQueue round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestMergeQueueRoundTrip:
+    def test_read_absent_returns_empty_queue(self, store: BeadStore) -> None:
+        q = store.read_merge_queue()
+        assert isinstance(q, MergeQueue)
+        assert q.queue == []
+
+    def test_write_and_read(self, store: BeadStore) -> None:
+        entry = MergeQueueEntry(
+            pr_number=187,
+            issue_number=42,
+            branch="42-test-slug",
+            enqueued_at="2026-03-04T10:10:00+00:00",
+        )
+        q = MergeQueue(v=BEAD_SCHEMA_VERSION, queue=[entry], updated_at="2026-03-04T10:10:00+00:00")
+        store.write_merge_queue(q)
+        loaded = store.read_merge_queue()
+        assert len(loaded.queue) == 1
+        assert loaded.queue[0].pr_number == 187
+        assert loaded.queue[0].branch == "42-test-slug"
+
+
+# ---------------------------------------------------------------------------
+# Atomic write: no partial files
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicWrite:
+    def test_no_tmp_file_after_write(self, store: BeadStore, tmp_path: Path) -> None:
+        bead = _make_work_bead()
+        store.write_work_bead(bead)
+        tmp_files = list((tmp_path / "beads" / "work").glob("*.tmp"))
+        assert tmp_files == [], "No .tmp files should remain after write"
+
+    def test_target_file_exists_after_write(self, store: BeadStore, tmp_path: Path) -> None:
+        bead = _make_work_bead()
+        store.write_work_bead(bead)
+        assert (tmp_path / "beads" / "work" / "42.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Corrupt file raises BeadCorruptError
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptFile:
+    def test_corrupt_work_bead_raises(self, store: BeadStore, tmp_path: Path) -> None:
+        p = tmp_path / "beads" / "work" / "42.json"
+        p.write_text("not json{{{", encoding="utf-8")
+        with pytest.raises(BeadCorruptError):
+            store.read_work_bead(42)
+
+    def test_corrupt_pr_bead_raises(self, store: BeadStore, tmp_path: Path) -> None:
+        p = tmp_path / "beads" / "prs" / "pr-187.json"
+        p.write_text("not json{{{", encoding="utf-8")
+        with pytest.raises(BeadCorruptError):
+            store.read_pr_bead(187)
+
+
+# ---------------------------------------------------------------------------
+# list_work_beads — state filtering
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkBeads:
+    def test_list_all(self, store: BeadStore) -> None:
+        store.write_work_bead(_make_work_bead(issue_number=1, state="claimed"))
+        store.write_work_bead(_make_work_bead(issue_number=2, state="pr_open"))
+        store.write_work_bead(_make_work_bead(issue_number=3, state="claimed"))
+        beads = store.list_work_beads()
+        assert len(beads) == 3
+
+    def test_filter_by_state(self, store: BeadStore) -> None:
+        store.write_work_bead(_make_work_bead(issue_number=1, state="claimed"))
+        store.write_work_bead(_make_work_bead(issue_number=2, state="pr_open"))
+        store.write_work_bead(_make_work_bead(issue_number=3, state="claimed"))
+        claimed = store.list_work_beads(state="claimed")
+        assert len(claimed) == 2
+        assert all(b.state == "claimed" for b in claimed)
+
+    def test_filter_no_match(self, store: BeadStore) -> None:
+        store.write_work_bead(_make_work_bead(issue_number=1, state="claimed"))
+        merged = store.list_work_beads(state="closed")
+        assert merged == []
+
+    def test_corrupt_file_skipped(self, store: BeadStore, tmp_path: Path) -> None:
+        store.write_work_bead(_make_work_bead(issue_number=1, state="claimed"))
+        # Inject a corrupt file
+        (tmp_path / "beads" / "work" / "99.json").write_text("bad json", encoding="utf-8")
+        beads = store.list_work_beads()
+        assert len(beads) == 1  # corrupt file skipped
+
+
+# ---------------------------------------------------------------------------
+# list_pr_beads — state filtering
+# ---------------------------------------------------------------------------
+
+
+class TestListPRBeads:
+    def test_filter_by_state(self, store: BeadStore) -> None:
+        store.write_pr_bead(_make_pr_bead(pr_number=1, state="open"))
+        store.write_pr_bead(_make_pr_bead(pr_number=2, state="merged"))
+        store.write_pr_bead(_make_pr_bead(pr_number=3, state="open"))
+        open_beads = store.list_pr_beads(state="open")
+        assert len(open_beads) == 2
+
+
+# ---------------------------------------------------------------------------
+# delete_work_bead
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteWorkBead:
+    def test_delete_removes_file(self, store: BeadStore) -> None:
+        bead = _make_work_bead()
+        store.write_work_bead(bead)
+        assert store.read_work_bead(42) is not None
+        store.delete_work_bead(42)
+        assert store.read_work_bead(42) is None
+
+    def test_delete_absent_is_noop(self, store: BeadStore) -> None:
+        # Should not raise
+        store.delete_work_bead(999)
+
+
+# ---------------------------------------------------------------------------
+# flush() — no-op when state_repo_path is None
+# ---------------------------------------------------------------------------
+
+
+class TestFlush:
+    def test_flush_noop_without_state_repo(self, tmp_path: Path) -> None:
+        store = BeadStore(beads_dir=tmp_path / "beads", state_repo_path=None)
+        # Should not raise and should not call subprocess
+        with patch("subprocess.run") as mock_run:
+            store.flush("test: flush noop")
+            mock_run.assert_not_called()
+
+    def test_flush_noop_when_repo_path_has_no_git_dir(self, tmp_path: Path) -> None:
+        fake_repo = tmp_path / "fake-repo"
+        fake_repo.mkdir()
+        store = BeadStore(beads_dir=tmp_path / "beads", state_repo_path=fake_repo)
+        with patch("subprocess.run") as mock_run:
+            store.flush("test: no .git dir")
+            mock_run.assert_not_called()
+
+    def test_flush_calls_git_when_dirty(self, tmp_path: Path) -> None:
+        repo = tmp_path / "state-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        store = BeadStore(beads_dir=tmp_path / "beads", state_repo_path=repo)
+        with patch("subprocess.run") as mock_run:
+            # Make git status return dirty output
+            mock_run.return_value = MagicMock(stdout="M beads/work/42.json\n", returncode=0)
+            store.flush("brimstone: claim #42")
+            # First call is git status --porcelain, subsequent are add/commit/push
+            assert mock_run.call_count >= 2
+
+    def test_flush_skips_commit_when_clean(self, tmp_path: Path) -> None:
+        repo = tmp_path / "state-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        store = BeadStore(beads_dir=tmp_path / "beads", state_repo_path=repo)
+        with patch("subprocess.run") as mock_run:
+            # git status returns empty (clean)
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            store.flush("brimstone: no-op")
+            assert mock_run.call_count == 1  # only the status check
+
+
+# ---------------------------------------------------------------------------
+# make_bead_store — path construction
+# ---------------------------------------------------------------------------
+
+
+class TestMakeBreadStore:
+    def test_beads_dir_from_repo_slug(self, tmp_path: Path) -> None:
+        config = MagicMock()
+        config.beads_dir = tmp_path / "beads"
+        config.state_repo = None
+
+        store = make_bead_store(config, "bread-wood/calculator")
+        expected = tmp_path / "beads" / "bread-wood" / "calculator"
+        assert store._beads_dir == expected
+
+    def test_expanduser_called(self, tmp_path: Path) -> None:
+        """Ensure ~ is expanded for the beads_dir path."""
+        config = MagicMock()
+        config.beads_dir = MagicMock()
+        config.beads_dir.expanduser.return_value = tmp_path / "beads"
+        config.state_repo = None
+
+        make_bead_store(config, "owner/repo")
+        config.beads_dir.expanduser.assert_called_once()
+
+    def test_no_state_repo_clone_when_state_repo_is_none(self, tmp_path: Path) -> None:
+        config = MagicMock()
+        config.beads_dir = tmp_path / "beads"
+        config.state_repo = None
+
+        with patch("subprocess.run") as mock_run:
+            store = make_bead_store(config, "owner/repo")
+            mock_run.assert_not_called()
+        assert store._state_repo_path is None
+
+    def test_state_repo_cloned_when_not_present(self, tmp_path: Path) -> None:
+        config = MagicMock()
+        config.beads_dir = tmp_path / "beads"
+        config.state_repo = "owner/state-repo"
+        config.state_repo_dir = MagicMock()
+        state_dir = tmp_path / "state-repos"
+        state_dir.mkdir()
+        config.state_repo_dir.expanduser.return_value = state_dir
+
+        with patch("subprocess.run") as mock_run:
+            store = make_bead_store(config, "owner/repo")
+            # Should have called gh repo clone
+            assert any("clone" in str(call) for call in mock_run.call_args_list), (
+                "Expected gh repo clone to be called"
+            )
+        expected_state_path = state_dir / "owner-state-repo"
+        assert store._state_repo_path == expected_state_path


### PR DESCRIPTION
## Summary

- Creates `src/brimstone/beads.py` with `WorkBead`, `PRBead`, `MergeQueue` dataclasses and `BeadStore` class
- `BeadStore` provides atomic JSON reads/writes (write-to-.tmp + `os.replace`) for issue/PR lifecycle state
- Optional git-backed state repo flush via `BeadStore.flush()` for multi-session portability
- Adds `beads_dir`, `state_repo`, `state_repo_dir` fields to `Config`
- Adds `beads` module row to CLAUDE.md
- 27 unit tests covering round-trips, atomicity, corruption handling, filtering, and factory

## Test plan

- [x] `uv run pytest tests/unit/test_beads.py` — 27/27 pass
- [x] `uv run pytest tests/unit/` — 470/470 pass
- [x] `uv run ruff check src/brimstone/beads.py tests/unit/test_beads.py` — clean
- [x] `uv run ruff format --check src/brimstone/beads.py tests/unit/test_beads.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)