### PR TITLE
feat(cli): add Deacon — zombie detection, recovery dispatch, and pool tick

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -56,6 +56,9 @@ DESIGN_LABEL: str = "stage/design"
 IMPL_LABEL: str = "stage/impl"
 BACKOFF_SLEEP_SECONDS: int = 30
 STALL_MAX_ITERATIONS: int = 5  # 5 × BACKOFF_SLEEP_SECONDS = 2.5 min before escalation
+DEACON_INTERVAL: int = 5  # run deacon scan every N pool iterations
+DEACON_TIMEOUT_MINUTES: float = 45.0
+DEACON_MAX_FIX_ATTEMPTS: int = 3
 
 
 def _auth_mode(config: Config) -> str:
@@ -1586,6 +1589,7 @@ def _run_persistent_pool(
     # In-memory fallback retry tracker used when store is None.
     _retry_counts: dict[int, int] = {}
     stall_count: int = 0
+    _deacon_tick: int = 0
     active: dict = {}
 
     fill_fn(active)
@@ -1744,6 +1748,18 @@ def _run_persistent_pool(
             # Success — delegate PR monitoring, triage, and worktree cleanup to on_success
             on_success(_issue, _branch, _worktree_path)
             session.save(checkpoint, checkpoint_path)
+
+        _deacon_tick += 1
+        if store is not None and _deacon_tick % DEACON_INTERVAL == 0:
+            active_numbers = {active[f][0]["number"] for f in active}
+            _deacon_scan(
+                repo=repo,
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers=active_numbers,
+                default_branch="",
+            )
 
         fill_fn(active)
 
@@ -2933,6 +2949,182 @@ def _process_merge_queue(
     queue.queue = remaining
     queue.updated_at = datetime.now(UTC).isoformat()
     store.write_merge_queue(queue)
+
+
+def _dispatch_recovery_agent(
+    pr_bead: PRBead,
+    work_bead: WorkBead,
+    repo: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    store: BeadStore,
+) -> None:
+    """Dispatch a recovery sub-agent for a zombie PR (timed-out, no active future).
+
+    Gathers PR diff, review comments, and latest CI logs, then runs a fix
+    agent.  Increments ``pr_bead.fix_attempts`` and writes the updated bead
+    before returning so repeated failures are capped by
+    :data:`DEACON_MAX_FIX_ATTEMPTS`.
+
+    Args:
+        pr_bead:    The PRBead for the stalled PR.
+        work_bead:  The WorkBead for the stalled issue.
+        repo:       Repository in ``owner/repo`` format.
+        config:     Validated Config instance.
+        checkpoint: Active Checkpoint instance (for logging).
+        store:      Active BeadStore for bead updates.
+    """
+    pr_number = pr_bead.pr_number
+    branch = pr_bead.branch
+    issue_number = pr_bead.issue_number
+
+    # Gather context
+    diff_result = _gh(
+        ["pr", "diff", str(pr_number)],
+        repo=repo,
+        check=False,
+    )
+    diff_text = (diff_result.stdout or "")[:3000]
+
+    reviews_result = _gh(
+        ["pr", "view", str(pr_number), "--json", "reviews,comments"],
+        repo=repo,
+        check=False,
+    )
+    reviews_text = (reviews_result.stdout or "")[:2000]
+
+    run_list = _gh(
+        ["run", "list", "--branch", branch, "--limit", "1", "--json", "databaseId"],
+        repo=repo,
+        check=False,
+    )
+    failure_logs = "(could not retrieve CI logs)"
+    try:
+        runs = json.loads(run_list.stdout or "[]")
+        if runs:
+            run_id_val = runs[0]["databaseId"]
+            log_result = _gh(
+                ["run", "view", str(run_id_val), "--log-failed"],
+                repo=repo,
+                check=False,
+            )
+            if log_result.returncode == 0 and log_result.stdout:
+                failure_logs = log_result.stdout[:4000]
+    except (json.JSONDecodeError, KeyError, IndexError):
+        pass
+
+    issue_result = _gh(
+        ["issue", "view", str(issue_number), "--json", "title,body"],
+        repo=repo,
+        check=False,
+    )
+    issue_text = (issue_result.stdout or "")[:2000]
+
+    prompt = (
+        f"You are recovering a stalled PR #{pr_number} in repository `{repo}`.\n"
+        f"Branch: `{branch}`\n"
+        f"Original issue #{issue_number}:\n```\n{issue_text}\n```\n\n"
+        f"PR diff (truncated):\n```diff\n{diff_text}\n```\n\n"
+        f"Review comments:\n```json\n{reviews_text}\n```\n\n"
+        f"Latest CI failure logs:\n```\n{failure_logs}\n```\n\n"
+        f"Steps:\n"
+        f"1. Clone the repo: WORK=$(mktemp -d) && gh repo clone {repo} $WORK\n"
+        f"2. cd $WORK && git checkout {branch} && git pull origin {branch}\n"
+        f"3. Diagnose issues from the diff, reviews, and CI logs above.\n"
+        f"4. Fix ALL issues in a single commit. Stay within files already on the branch.\n"
+        f"5. Verify: uv run ruff check && uv run pytest\n"
+        f"6. git add -A && git commit -m 'fix: deacon recovery on PR #{pr_number}' && git push\n"
+        f"7. STOP. Output exactly: Done.\n"
+    )
+
+    logger.log_conductor_event(
+        run_id=checkpoint.run_id,
+        phase="deacon",
+        event_type="recovery_dispatched",
+        payload={
+            "pr_number": pr_number,
+            "issue_number": issue_number,
+            "branch": branch,
+            "fix_attempts": pr_bead.fix_attempts,
+        },
+        log_dir=config.log_dir.expanduser(),
+    )
+
+    env = build_subprocess_env(config)
+    runner.run(
+        prompt=prompt,
+        allowed_tools=["Bash"],
+        env=env,
+        max_turns=60,
+        timeout_seconds=config.agent_timeout_minutes * 60,
+        model=config.model,
+        prefix=f"[deacon {branch}] ",
+    )
+
+    pr_bead.fix_attempts += 1
+    store.write_pr_bead(pr_bead)
+
+
+def _deacon_scan(
+    repo: str,
+    config: Config,
+    checkpoint: Checkpoint,
+    store: BeadStore,
+    active_issue_numbers: set[int],
+    default_branch: str,
+) -> None:
+    """Scan for zombie PRs and dispatch recovery agents or exhaust issues.
+
+    A zombie is a WorkBead with ``state="claimed"`` and ``claimed_at`` older
+    than :data:`DEACON_TIMEOUT_MINUTES` whose ``issue_number`` is NOT in the
+    set of currently-active futures.
+
+    For each zombie:
+    - If ``pr_bead.fix_attempts >= DEACON_MAX_FIX_ATTEMPTS``: exhaust the issue.
+    - Otherwise: dispatch a recovery agent via :func:`_dispatch_recovery_agent`.
+
+    Args:
+        repo:                 Repository in ``owner/repo`` format.
+        config:               Validated Config instance.
+        checkpoint:           Active Checkpoint instance (for logging).
+        store:                Active BeadStore for reading/writing bead state.
+        active_issue_numbers: Issue numbers currently being processed by live futures.
+        default_branch:       Default branch name (unused here, kept for future use).
+    """
+    for pr_bead in store.list_pr_beads():
+        if pr_bead.state == "merged":
+            continue
+        if pr_bead.issue_number in active_issue_numbers:
+            continue  # agent is still running — not a zombie
+
+        work_bead = store.read_work_bead(pr_bead.issue_number)
+        if not work_bead or not work_bead.claimed_at:
+            continue
+
+        claimed_dt = datetime.fromisoformat(work_bead.claimed_at)
+        elapsed_min = (datetime.now(UTC) - claimed_dt).total_seconds() / 60
+        if elapsed_min < DEACON_TIMEOUT_MINUTES:
+            continue
+
+        # Zombie detected
+        logger.log_conductor_event(
+            run_id=checkpoint.run_id,
+            phase="deacon",
+            event_type="zombie_detected",
+            payload={
+                "issue_number": pr_bead.issue_number,
+                "pr_number": pr_bead.pr_number,
+                "elapsed_minutes": round(elapsed_min, 1),
+                "fix_attempts": pr_bead.fix_attempts,
+            },
+            log_dir=config.log_dir.expanduser(),
+        )
+
+        if pr_bead.fix_attempts >= DEACON_MAX_FIX_ATTEMPTS:
+            reason = f"deacon: max fix attempts ({DEACON_MAX_FIX_ATTEMPTS}) exceeded"
+            _exhaust_issue(repo, pr_bead.issue_number, reason, store)
+        else:
+            _dispatch_recovery_agent(pr_bead, work_bead, repo, config, checkpoint, store)
 
 
 def _dispatch_ci_fix_agent(

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -1698,3 +1698,223 @@ class TestProcessMergeQueue:
         # write_merge_queue should have been called (entry enqueued)
         assert store.write_merge_queue.call_count >= 1
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# TestDeaconScan
+# ---------------------------------------------------------------------------
+
+
+class TestDeaconScan:
+    """Verify _deacon_scan() zombie detection and recovery/exhaustion logic."""
+
+    def _make_pr_bead(self, issue_number: int = 7, fix_attempts: int = 0) -> MagicMock:
+        from brimstone.beads import PRBead
+
+        bead = PRBead(
+            v=1,
+            pr_number=55,
+            issue_number=issue_number,
+            branch=f"{issue_number}-feature",
+            state="ci_failing",
+            ci_state="failing",
+            conflict_state=None,
+            fix_attempts=fix_attempts,
+            feedback=[],
+            created_at="2026-03-04T00:00:00+00:00",
+            merged_at=None,
+        )
+        return bead
+
+    def _make_work_bead(
+        self, issue_number: int = 7, claimed_at: str | None = None
+    ) -> MagicMock:
+        from brimstone.beads import WorkBead
+
+        if claimed_at is None:
+            # Default: 2 hours ago (well past DEACON_TIMEOUT_MINUTES=45)
+            from datetime import UTC, datetime, timedelta
+
+            claimed_at = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        return WorkBead(
+            v=1,
+            issue_number=issue_number,
+            title="Test issue",
+            milestone="v0.1.0",
+            stage="impl",
+            module="cli",
+            priority="P2",
+            state="claimed",
+            branch=f"{issue_number}-feature",
+            pr_id="pr-55",
+            retry_count=0,
+            claimed_at=claimed_at,
+            closed_at=None,
+        )
+
+    def test_no_zombies_does_nothing(self, tmp_path: Path) -> None:
+        """When no beads exist, scan is a no-op."""
+        from brimstone.cli import _deacon_scan
+
+        store = MagicMock()
+        store.list_pr_beads.return_value = []
+        config = make_config(log_dir=tmp_path)
+        checkpoint = make_checkpoint()
+
+        with patch("brimstone.cli.logger.log_conductor_event") as mock_log:
+            _deacon_scan(
+                repo="owner/repo",
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers=set(),
+                default_branch="mainline",
+            )
+
+        mock_log.assert_not_called()
+        store.write_pr_bead.assert_not_called()
+
+    def test_active_issue_skipped(self, tmp_path: Path) -> None:
+        """An issue currently in an active future is NOT treated as a zombie."""
+        from brimstone.cli import _deacon_scan
+
+        pr_bead = self._make_pr_bead(issue_number=7)
+        store = MagicMock()
+        store.list_pr_beads.return_value = [pr_bead]
+        config = make_config(log_dir=tmp_path)
+        checkpoint = make_checkpoint()
+
+        with patch("brimstone.cli._dispatch_recovery_agent") as mock_dispatch:
+            _deacon_scan(
+                repo="owner/repo",
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers={7},  # issue 7 is active
+                default_branch="mainline",
+            )
+
+        mock_dispatch.assert_not_called()
+
+    def test_merged_bead_skipped(self, tmp_path: Path) -> None:
+        """A PRBead with state='merged' is never treated as a zombie."""
+        from brimstone.beads import PRBead
+        from brimstone.cli import _deacon_scan
+
+        pr_bead = PRBead(
+            v=1,
+            pr_number=55,
+            issue_number=7,
+            branch="7-feature",
+            state="merged",
+            ci_state=None,
+            conflict_state=None,
+            fix_attempts=0,
+            feedback=[],
+            created_at="2026-03-04T00:00:00+00:00",
+            merged_at="2026-03-04T01:00:00+00:00",
+        )
+        store = MagicMock()
+        store.list_pr_beads.return_value = [pr_bead]
+        config = make_config(log_dir=tmp_path)
+        checkpoint = make_checkpoint()
+
+        with patch("brimstone.cli._dispatch_recovery_agent") as mock_dispatch:
+            _deacon_scan(
+                repo="owner/repo",
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers=set(),
+                default_branch="mainline",
+            )
+
+        mock_dispatch.assert_not_called()
+
+    def test_zombie_detected_dispatches_recovery(self, tmp_path: Path) -> None:
+        """A timed-out, non-active issue triggers _dispatch_recovery_agent."""
+        from brimstone.cli import _deacon_scan
+
+        pr_bead = self._make_pr_bead(issue_number=7, fix_attempts=0)
+        work_bead = self._make_work_bead(issue_number=7)
+        store = MagicMock()
+        store.list_pr_beads.return_value = [pr_bead]
+        store.read_work_bead.return_value = work_bead
+        config = make_config(log_dir=tmp_path)
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("brimstone.cli._dispatch_recovery_agent") as mock_dispatch,
+            patch("brimstone.cli.logger.log_conductor_event"),
+        ):
+            _deacon_scan(
+                repo="owner/repo",
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers=set(),
+                default_branch="mainline",
+            )
+
+        mock_dispatch.assert_called_once_with(
+            pr_bead, work_bead, "owner/repo", config, checkpoint, store
+        )
+
+    def test_zombie_at_max_attempts_exhausts_issue(self, tmp_path: Path) -> None:
+        """A zombie at DEACON_MAX_FIX_ATTEMPTS calls _exhaust_issue instead of recovery."""
+        from brimstone.cli import DEACON_MAX_FIX_ATTEMPTS, _deacon_scan
+
+        pr_bead = self._make_pr_bead(issue_number=7, fix_attempts=DEACON_MAX_FIX_ATTEMPTS)
+        work_bead = self._make_work_bead(issue_number=7)
+        store = MagicMock()
+        store.list_pr_beads.return_value = [pr_bead]
+        store.read_work_bead.return_value = work_bead
+        config = make_config(log_dir=tmp_path)
+        checkpoint = make_checkpoint()
+
+        with (
+            patch("brimstone.cli._exhaust_issue") as mock_exhaust,
+            patch("brimstone.cli._dispatch_recovery_agent") as mock_dispatch,
+            patch("brimstone.cli.logger.log_conductor_event"),
+        ):
+            _deacon_scan(
+                repo="owner/repo",
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers=set(),
+                default_branch="mainline",
+            )
+
+        mock_exhaust.assert_called_once()
+        mock_dispatch.assert_not_called()
+        # Verify reason string mentions max attempts
+        call_args = mock_exhaust.call_args
+        assert "max fix attempts" in call_args[0][2] or "max fix attempts" in str(call_args)
+
+    def test_recent_claim_not_a_zombie(self, tmp_path: Path) -> None:
+        """An issue claimed only 5 minutes ago is NOT a zombie."""
+        from datetime import UTC, datetime, timedelta
+
+        from brimstone.cli import _deacon_scan
+
+        pr_bead = self._make_pr_bead(issue_number=7)
+        recent_claimed_at = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
+        work_bead = self._make_work_bead(issue_number=7, claimed_at=recent_claimed_at)
+        store = MagicMock()
+        store.list_pr_beads.return_value = [pr_bead]
+        store.read_work_bead.return_value = work_bead
+        config = make_config(log_dir=tmp_path)
+        checkpoint = make_checkpoint()
+
+        with patch("brimstone.cli._dispatch_recovery_agent") as mock_dispatch:
+            _deacon_scan(
+                repo="owner/repo",
+                config=config,
+                checkpoint=checkpoint,
+                store=store,
+                active_issue_numbers=set(),
+                default_branch="mainline",
+            )
+
+        mock_dispatch.assert_not_called()

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -1726,9 +1726,7 @@ class TestDeaconScan:
         )
         return bead
 
-    def _make_work_bead(
-        self, issue_number: int = 7, claimed_at: str | None = None
-    ) -> MagicMock:
+    def _make_work_bead(self, issue_number: int = 7, claimed_at: str | None = None) -> MagicMock:
         from brimstone.beads import WorkBead
 
         if claimed_at is None:


### PR DESCRIPTION
## Summary
- Adds `DEACON_INTERVAL`, `DEACON_TIMEOUT_MINUTES`, `DEACON_MAX_FIX_ATTEMPTS` constants
- Adds `_deacon_scan()`: scans PRBeads for zombies (timed-out, no active future); dispatches recovery agent or exhausts issue when max attempts exceeded
- Adds `_dispatch_recovery_agent()`: gathers PR diff, reviews, CI logs, runs recovery sub-agent
- Wires `_deacon_scan()` into `_run_persistent_pool()` every `DEACON_INTERVAL` iterations via `_deacon_tick` counter
- Adds `TestDeaconScan` (6 tests): no zombies, active issue skipped, merged bead skipped, zombie dispatches recovery, zombie at max exhausts, recent claim not a zombie

## Test plan
- [x] 520 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)