### PR TITLE
refactor(cli): remove dead functions and legacy checkpoint writes (PR 7b)

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -618,37 +618,6 @@ def _gh(
     return subprocess.run(cmd, capture_output=True, text=True, check=check)
 
 
-def _list_in_progress_issues(repo: str, milestone: str, label: str) -> list[dict[str, Any]]:
-    """Return open issues with in-progress label for *milestone* scoped to *label*.
-
-    Used at worker startup to resume monitoring PRs from a previous run.
-    """
-    result = _gh(
-        [
-            "issue",
-            "list",
-            "--state",
-            "open",
-            "--label",
-            f"{label},in-progress",
-            "--milestone",
-            milestone,
-            "--json",
-            "number,title",
-            "--limit",
-            "50",
-        ],
-        repo=repo,
-        check=False,
-    )
-    if result.returncode != 0:
-        return []
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return []
-
-
 def _resume_open_prs(
     repo: str,
     milestone: str,
@@ -779,21 +748,20 @@ def _resume_stale_issues(
     Called at the start of research-worker, design-worker, and impl-worker.
     """
     handled: set[int] = set()
-    if store is not None:
-        _LABEL_TO_STAGE = {
-            "stage/research": "research",
-            "stage/impl": "impl",
-            "stage/design": "design",
-        }
-        stage_name = _LABEL_TO_STAGE.get(label, "")
-        claimed_beads = [
-            b
-            for b in store.list_work_beads(state="claimed")
-            if b.milestone == milestone and (not stage_name or b.stage == stage_name)
-        ]
-        stale_iter: list[int] = [b.issue_number for b in claimed_beads]
-    else:
-        stale_iter = [stale["number"] for stale in _list_in_progress_issues(repo, milestone, label)]
+    if store is None:
+        return handled
+    _LABEL_TO_STAGE = {
+        "stage/research": "research",
+        "stage/impl": "impl",
+        "stage/design": "design",
+    }
+    stage_name = _LABEL_TO_STAGE.get(label, "")
+    claimed_beads = [
+        b
+        for b in store.list_work_beads(state="claimed")
+        if b.milestone == milestone and (not stage_name or b.stage == stage_name)
+    ]
+    stale_iter: list[int] = [b.issue_number for b in claimed_beads]
     for stale_number in stale_iter:
         found = _find_pr_for_issue(repo, stale_number)
         if found is not None:
@@ -2914,8 +2882,6 @@ def _process_merge_queue(
                 work_bead.state = "closed"
                 work_bead.closed_at = now_str
                 store.write_work_bead(work_bead)
-            # Keep legacy checkpoint update for backward-compat until PR 7b
-            checkpoint.completed_prs.append(pr_number)
             session.save(checkpoint, checkpoint_path)
             store.flush(f"brimstone: #{issue_number} merged via pr-{pr_number}")
             logger.log_conductor_event(
@@ -3125,332 +3091,6 @@ def _deacon_scan(
             _exhaust_issue(repo, pr_bead.issue_number, reason, store)
         else:
             _dispatch_recovery_agent(pr_bead, work_bead, repo, config, checkpoint, store)
-
-
-def _dispatch_ci_fix_agent(
-    pr_number: int,
-    branch: str,
-    repo: str,
-    config: Config,
-    checkpoint: Checkpoint,
-    issue_number: int,
-) -> None:
-    """Dispatch a fix agent to repair CI failures on a PR branch.
-
-    Reads the latest failing CI run logs, then dispatches a Claude agent that
-    checks out the branch, diagnoses and fixes the failures, and pushes a fix
-    commit. The caller should continue polling after this returns.
-
-    Args:
-        pr_number:    GitHub PR number.
-        branch:       Branch name for the PR.
-        repo:         Repository in ``owner/repo`` format.
-        config:       Config instance (provides model, env, timeouts).
-        checkpoint:   Checkpoint instance for logging.
-        issue_number: Original issue number (for logging).
-    """
-    logger.log_conductor_event(
-        run_id=checkpoint.run_id,
-        phase="ci_check",
-        event_type="ci_fix_dispatched",
-        payload={"pr_number": pr_number, "issue_number": issue_number, "branch": branch},
-        log_dir=config.log_dir.expanduser(),
-    )
-
-    # Fetch failure logs from the most recent CI run on this branch.
-    run_list = _gh(
-        ["run", "list", "--branch", branch, "--limit", "1", "--json", "databaseId"],
-        repo=repo,
-        check=False,
-    )
-    failure_logs = "(could not retrieve CI logs)"
-    try:
-        runs = json.loads(run_list.stdout or "[]")
-        if runs:
-            run_id = runs[0]["databaseId"]
-            log_result = _gh(
-                ["run", "view", str(run_id), "--log-failed"],
-                repo=repo,
-                check=False,
-            )
-            if log_result.returncode == 0 and log_result.stdout:
-                failure_logs = log_result.stdout[:4000]
-    except (json.JSONDecodeError, KeyError, IndexError):
-        pass
-
-    prompt = (
-        f"You are fixing CI failures on PR #{pr_number} in repository `{repo}`.\n"
-        f"Branch: `{branch}`\n\n"
-        f"CI failure logs:\n```\n{failure_logs}\n```\n\n"
-        f"Steps:\n"
-        f"1. Clone the repo into a temp directory:\n"
-        f"   WORK=$(mktemp -d) && gh repo clone {repo} $WORK\n"
-        f"2. cd $WORK && git checkout {branch} && git pull origin {branch}\n"
-        f"3. Diagnose the failure from the logs above. Fix the root cause in the source files.\n"
-        f"   - Lint errors: remove unused imports, fix formatting\n"
-        f"   - Test failures: fix the implementation or correct a wrong test expectation\n"
-        f"   - Type errors: add or fix type annotations\n"
-        f"   Stay within the files already modified on this branch"
-        f" — do not refactor unrelated code.\n"
-        f"4. Run CI locally to verify the fix:\n"
-        f"   make lint && make test   (or uv run ruff check && uv run pytest)\n"
-        f"5. Commit and push:\n"
-        f"   git add -A && git commit -m 'fix: repair CI on PR #{pr_number}' && git push\n"
-        f"6. STOP.\n"
-    )
-
-    env = build_subprocess_env(config)
-    runner.run(
-        prompt=prompt,
-        allowed_tools=["Bash"],
-        env=env,
-        max_turns=40,
-        timeout_seconds=config.agent_timeout_minutes * 60,
-        model=config.model,
-        prefix=f"[ci-fix {branch}] ",
-    )
-
-
-def _collect_pr_review_context(pr_number: int, repo: str) -> dict[str, Any]:
-    """Collect all review feedback from a PR: formal reviews, inline comments, thread comments.
-
-    Returns a dict with keys:
-        ``reviews``        — list of formal review dicts (state, author, body)
-        ``inline``         — list of inline code comment dicts (path, line, body, author)
-        ``thread``         — list of PR thread comment dicts (body, author)
-        ``blocking_logins``— set of reviewer logins whose state is CHANGES_REQUESTED
-    """
-    context: dict[str, Any] = {
-        "reviews": [],
-        "inline": [],
-        "thread": [],
-        "blocking_logins": set(),
-    }
-
-    # Formal reviews (state + body)
-    reviews_result = _gh(
-        ["pr", "view", str(pr_number), "--json", "reviews"],
-        repo=repo,
-        check=False,
-    )
-    if reviews_result.returncode == 0:
-        try:
-            data = json.loads(reviews_result.stdout)
-            raw_reviews = data.get("reviews", [])
-            # Deduplicate: keep the latest review per author
-            latest: dict[str, dict] = {}
-            for r in raw_reviews:
-                login = (r.get("author") or {}).get("login", "unknown")
-                latest[login] = r
-            for login, r in latest.items():
-                state = (r.get("state") or "").upper()
-                entry = {
-                    "author": login,
-                    "state": state,
-                    "body": (r.get("body") or "").strip(),
-                }
-                context["reviews"].append(entry)
-                if state == "CHANGES_REQUESTED":
-                    context["blocking_logins"].add(login)
-        except (json.JSONDecodeError, AttributeError):
-            pass
-
-    # Inline code comments
-    inline_result = _gh(
-        ["api", f"repos/{repo}/pulls/{pr_number}/comments"],
-        repo=None,
-        check=False,
-    )
-    if inline_result.returncode == 0:
-        try:
-            for c in json.loads(inline_result.stdout or "[]")[:30]:
-                context["inline"].append(
-                    {
-                        "author": (c.get("user") or {}).get("login", "?"),
-                        "path": c.get("path") or "?",
-                        "line": c.get("line") or c.get("original_line") or "?",
-                        "body": (c.get("body") or "").strip(),
-                    }
-                )
-        except (json.JSONDecodeError, AttributeError):
-            pass
-
-    # PR thread comments
-    thread_result = _gh(
-        ["pr", "view", str(pr_number), "--json", "comments"],
-        repo=repo,
-        check=False,
-    )
-    if thread_result.returncode == 0:
-        try:
-            data = json.loads(thread_result.stdout)
-            for c in (data.get("comments") or [])[:20]:
-                context["thread"].append(
-                    {
-                        "author": (c.get("author") or {}).get("login", "?"),
-                        "body": (c.get("body") or "").strip(),
-                    }
-                )
-        except (json.JSONDecodeError, AttributeError):
-            pass
-
-    return context
-
-
-def _dismiss_stale_change_requests(pr_number: int, repo: str, logins: set[str]) -> None:
-    """Dismiss CHANGES_REQUESTED reviews for *logins* after fixes have been pushed.
-
-    Called after a review-fix agent pushes changes so the stale blocking reviews
-    don't prevent the squash merge. Only dismisses reviews from *logins* — human
-    reviews that were not specifically addressed are left intact.
-
-    Args:
-        pr_number: GitHub PR number.
-        repo:      Repository in ``owner/repo`` format.
-        logins:    Set of reviewer logins whose CHANGES_REQUESTED reviews to dismiss.
-    """
-    # Fetch current reviews with IDs
-    result = _gh(
-        ["api", f"repos/{repo}/pulls/{pr_number}/reviews"],
-        repo=None,
-        check=False,
-    )
-    if result.returncode != 0:
-        return
-    try:
-        reviews = json.loads(result.stdout or "[]")
-    except json.JSONDecodeError:
-        return
-
-    for review in reviews:
-        state = (review.get("state") or "").upper()
-        login = (review.get("user") or {}).get("login", "")
-        if state == "CHANGES_REQUESTED" and login in logins:
-            review_id = review.get("id")
-            if review_id:
-                _gh(
-                    [
-                        "api",
-                        "--method",
-                        "PUT",
-                        f"repos/{repo}/pulls/{pr_number}/reviews/{review_id}/dismissals",
-                        "-f",
-                        "message=Review feedback addressed in latest commit.",
-                    ],
-                    repo=None,
-                    check=False,
-                )
-
-
-def _handle_pr_review_feedback(
-    pr_number: int,
-    branch: str,
-    repo: str,
-    config: Config,
-    checkpoint: Checkpoint,
-    issue_number: int,
-) -> str:
-    """Collect all PR review feedback, dispatch a fix agent, and dismiss stale reviews.
-
-    Gathers formal review bodies, inline code comments, and PR thread comments from
-    all reviewers (human and automated, including Claude Code). Dispatches a single
-    fix agent with full context. After the agent pushes fixes, dismisses stale
-    CHANGES_REQUESTED reviews so they no longer block the squash merge.
-
-    Returns:
-        ``"fixed"``    — fix agent ran; caller should re-poll CI before merging.
-        ``"no_feedback"`` — no actionable feedback found; caller may merge.
-        ``"error"``    — could not read feedback; caller should escalate.
-    """
-    ctx = _collect_pr_review_context(pr_number, repo)
-
-    # Check if there is any substantive feedback to act on
-    has_formal = any(r["body"] for r in ctx["reviews"])
-    has_inline = bool(ctx["inline"])
-    has_thread = any(c["body"] and not c["author"].endswith("[bot]") for c in ctx["thread"])
-    if not has_formal and not has_inline and not has_thread:
-        return "no_feedback"
-
-    # Format reviews section
-    reviews_text = ""
-    for r in ctx["reviews"]:
-        state_tag = f"[{r['state']}]" if r["state"] else ""
-        body_text = r["body"] or "(no body)"
-        reviews_text += f"- **{r['author']}** {state_tag}:\n  {body_text}\n\n"
-
-    # Format inline comments
-    inline_text = ""
-    for c in ctx["inline"]:
-        inline_text += f"- `{c['path']}` line {c['line']} (@{c['author']}):\n  {c['body']}\n\n"
-
-    # Format thread comments (skip bots and empty)
-    thread_text = ""
-    for c in ctx["thread"]:
-        if c["body"] and not c["author"].endswith("[bot]"):
-            thread_text += f"- **@{c['author']}**: {c['body']}\n\n"
-
-    blocking = sorted(ctx["blocking_logins"])
-    blocking_str = ", ".join(f"@{login}" for login in blocking) or "none"
-
-    logger.log_conductor_event(
-        run_id=checkpoint.run_id,
-        phase="review",
-        event_type="review_feedback_dispatched",
-        payload={
-            "pr_number": pr_number,
-            "issue_number": issue_number,
-            "blocking_reviewers": blocking,
-            "inline_count": len(ctx["inline"]),
-            "thread_comment_count": len(ctx["thread"]),
-        },
-        log_dir=config.log_dir.expanduser(),
-    )
-
-    prompt = (
-        f"You are addressing review feedback on PR #{pr_number} in repository `{repo}`.\n"
-        f"Branch: `{branch}`\n"
-        f"Reviewers requesting changes: {blocking_str}\n\n"
-        f"## Formal Reviews\n{reviews_text or '(none)'}\n"
-        f"## Inline Code Comments\n{inline_text or '(none)'}\n"
-        f"## PR Thread Comments\n{thread_text or '(none)'}\n\n"
-        f"## Instructions\n"
-        f"1. Clone the repo:\n"
-        f"   WORK=$(mktemp -d) && gh repo clone {repo} $WORK\n"
-        f"2. cd $WORK && git checkout {branch} && git pull origin {branch}\n"
-        f"3. Triage every piece of feedback:\n"
-        f"   **Fix now**: correctness bugs, lint/type errors, broken tests, clear API mistakes → "
-        f"fix in the source, run tests to verify.\n"
-        f"   **File issue**: valid feedback that is out of scope for this PR → "
-        f"   `gh issue create --repo {repo} --title '...' --body '...'` "
-        f"   then comment on the PR: `gh pr comment {pr_number} --repo {repo} "
-        f"--body 'Filed as #<N>'`\n"
-        f"   **Skip**: false positives, style nitpicks, subjective preferences → "
-        f"   `gh pr comment {pr_number} --repo {repo} --body 'Skipping: <reason>'`\n"
-        f"4. Run lint and tests locally to confirm no regressions:\n"
-        f"   make lint && make test   (or: uv run ruff check && uv run pytest)\n"
-        f"5. Commit and push ALL fixes in a single commit:\n"
-        f"   git add -A && git commit -m 'fix: address review feedback on PR #{pr_number}' "
-        f"&& git push\n"
-        f"6. STOP — do not merge.\n"
-    )
-
-    env = build_subprocess_env(config)
-    runner.run(
-        prompt=prompt,
-        allowed_tools=["Bash"],
-        env=env,
-        max_turns=50,
-        timeout_seconds=config.agent_timeout_minutes * 60,
-        model=config.model,
-        prefix=f"[review-fix {branch}] ",
-    )
-
-    # Dismiss stale CHANGES_REQUESTED reviews from the reviewers we just addressed.
-    # This unblocks the squash merge; CI will re-run on the new commit.
-    if ctx["blocking_logins"]:
-        _dismiss_stale_change_requests(pr_number, repo, ctx["blocking_logins"])
-
-    return "fixed"
 
 
 def _create_worktree(branch: str, repo_root: str, default_branch: str = "main") -> str | None:
@@ -4042,7 +3682,6 @@ def _run_impl_worker(
                 _unclaim_issue(repo=repo, issue_number=issue_number, store=store)
                 _remove_worktree(worktree_path, repo_root)
                 return
-            checkpoint.open_prs[branch] = pr_number
             session.save(checkpoint, checkpoint_path)
             logger.log_conductor_event(
                 run_id=checkpoint.run_id,

--- a/tests/integration/test_research.py
+++ b/tests/integration/test_research.py
@@ -34,7 +34,6 @@ from tests.integration.conftest import (
 _BASE_PATCHES = {
     "milestone_exists": "brimstone.cli._milestone_exists",
     "default_branch": "brimstone.cli._get_default_branch_for_repo",
-    "in_progress": "brimstone.cli._list_in_progress_issues",
     "claim": "brimstone.cli._claim_issue",
     "unclaim": "brimstone.cli._unclaim_issue",
     "find_pr": "brimstone.cli._find_pr_for_issue",
@@ -73,7 +72,6 @@ class TestResearchWorkerHappyPath:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch(_BASE_PATCHES["claim"]),
             patch(_BASE_PATCHES["unclaim"]),
             patch(_BASE_PATCHES["find_pr"], return_value=None),
@@ -112,7 +110,6 @@ class TestResearchWorkerHappyPath:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch(_BASE_PATCHES["claim"]),
             patch(_BASE_PATCHES["unclaim"]),
             patch(_BASE_PATCHES["find_pr"], return_value=None),
@@ -163,7 +160,6 @@ class TestResearchWorkerHappyPath:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch(_BASE_PATCHES["claim"], side_effect=fake_claim),
             patch(_BASE_PATCHES["unclaim"]),
             patch(_BASE_PATCHES["find_pr"], return_value=None),
@@ -199,7 +195,6 @@ class TestResearchWorkerHappyPath:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch("brimstone.cli._list_open_issues_by_label", return_value=[]),
             patch("brimstone.cli._run_completion_gate", side_effect=fake_gate),
         ):
@@ -234,7 +229,6 @@ class TestResearchWorkerHappyPath:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch("brimstone.cli._list_open_issues_by_label", return_value=[issue]),
             # All issues non-blocking
             patch(_BASE_PATCHES["classify"], return_value=([], [issue])),
@@ -271,7 +265,6 @@ class TestResearchWorkerErrorHandling:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch(_BASE_PATCHES["claim"]),
             patch(_BASE_PATCHES["unclaim"]),
             patch(_BASE_PATCHES["find_pr"], return_value=None),
@@ -315,7 +308,6 @@ class TestResearchWorkerErrorHandling:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch(_BASE_PATCHES["claim"]),
             patch(_BASE_PATCHES["unclaim"], side_effect=fake_unclaim),
             patch(_BASE_PATCHES["find_pr"], return_value=None),
@@ -343,7 +335,27 @@ class TestResearchWorkerErrorHandling:
         os.chdir(git_repo)
         config = make_config(tmp_path)
         checkpoint = make_checkpoint()
-        stale = make_issue(99, "Stale from crashed session")
+
+        from brimstone.beads import WorkBead
+
+        stale_bead = WorkBead(
+            v=1,
+            issue_number=99,
+            title="Stale from crashed session",
+            milestone="v0.1.0",
+            stage="research",
+            module="cli",
+            priority="P2",
+            state="claimed",
+            branch="99-stale-branch",
+        )
+        store = MagicMock()
+        store.list_work_beads.return_value = [stale_bead]
+        store.read_pr_bead.return_value = None
+        store.write_pr_bead.return_value = None
+        store.read_work_bead.return_value = stale_bead
+        store.write_work_bead.return_value = None
+        store.flush.return_value = None
 
         unclaimed: list[int] = []
 
@@ -353,7 +365,6 @@ class TestResearchWorkerErrorHandling:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[stale]),
             patch(_BASE_PATCHES["unclaim"], side_effect=fake_unclaim),
             # _find_pr_for_issue returns None → no open PR
             patch(_BASE_PATCHES["find_pr"], return_value=None),
@@ -367,6 +378,7 @@ class TestResearchWorkerErrorHandling:
                 milestone="v0.1.0",
                 config=config,
                 checkpoint=checkpoint,
+                store=store,
             )
 
         assert 99 in unclaimed, "Stale in-progress issue with no PR must be unclaimed"
@@ -413,7 +425,6 @@ class TestResearchWorkerParallelDispatch:
         with (
             patch(_BASE_PATCHES["milestone_exists"], return_value=True),
             patch(_BASE_PATCHES["default_branch"], return_value="mainline"),
-            patch(_BASE_PATCHES["in_progress"], return_value=[]),
             patch(_BASE_PATCHES["claim"]),
             patch(_BASE_PATCHES["unclaim"], side_effect=fake_unclaim),
             patch(_BASE_PATCHES["find_pr"], return_value=None),

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -32,7 +32,6 @@ from brimstone.cli import (
     _find_pr_for_issue,
     _get_pr_checks_status,
     _get_review_status,
-    _handle_pr_review_feedback,
     _list_open_issues_by_label,
     _monitor_pr,
     _rebase_branch,
@@ -520,95 +519,6 @@ class TestFindPrForIssue:
         with patch("brimstone.cli._gh") as mock_gh:
             mock_gh.return_value = make_gh_result(stdout=self._prs(prs))
             assert _find_pr_for_issue("owner/repo", 42) is None
-
-
-# ---------------------------------------------------------------------------
-# _handle_pr_review_feedback — comprehensive review handler
-# ---------------------------------------------------------------------------
-
-
-class TestHandlePrReviewFeedback:
-    def _make_gh_side_effect(self, reviews, inline, thread):
-        """Return a side_effect callable that returns different payloads per call."""
-        calls = iter(
-            [
-                make_gh_result(stdout=json.dumps({"reviews": reviews})),  # pr view --json reviews
-                make_gh_result(stdout=json.dumps(inline)),  # api pulls/comments
-                make_gh_result(stdout=json.dumps({"comments": thread})),  # pr view --json comments
-            ]
-        )
-
-        def _side_effect(*args, **kwargs):
-            try:
-                return next(calls)
-            except StopIteration:
-                return make_gh_result(stdout="{}")
-
-        return _side_effect
-
-    def test_dispatches_fix_agent_when_changes_requested(self) -> None:
-        reviews = [
-            {
-                "author": {"login": "claude[bot]"},
-                "state": "CHANGES_REQUESTED",
-                "body": "Please rename this variable.",
-            }
-        ]
-        inline = [
-            {
-                "user": {"login": "claude[bot]"},
-                "path": "src/foo.py",
-                "line": 10,
-                "body": "Rename x to config.",
-            }
-        ]
-        thread = []
-
-        gh_side_effect = self._make_gh_side_effect(reviews, inline, thread)
-        with (
-            patch("brimstone.cli._gh", side_effect=gh_side_effect),
-            patch("brimstone.cli.runner.run") as mock_run,
-            patch("brimstone.cli.build_subprocess_env", return_value={}),
-            patch("brimstone.cli._dismiss_stale_change_requests"),
-        ):
-            mock_run.return_value = make_run_result()
-            result = _handle_pr_review_feedback(
-                pr_number=99,
-                branch="42-add-config",
-                repo="owner/repo",
-                config=make_config(),
-                checkpoint=make_checkpoint(),
-                issue_number=42,
-            )
-
-        assert result == "fixed"
-        mock_run.assert_called_once()
-        prompt = mock_run.call_args[1]["prompt"]
-        assert "PR #99" in prompt
-        assert "42-add-config" in prompt
-        assert "rename" in prompt.lower()
-
-    def test_returns_no_feedback_when_nothing_actionable(self) -> None:
-        reviews = [{"author": {"login": "claude[bot]"}, "state": "APPROVED", "body": ""}]
-        inline = []
-        thread = []
-
-        gh_side_effect2 = self._make_gh_side_effect(reviews, inline, thread)
-        with (
-            patch("brimstone.cli._gh", side_effect=gh_side_effect2),
-            patch("brimstone.cli.runner.run") as mock_run,
-        ):
-            result = _handle_pr_review_feedback(
-                pr_number=99,
-                branch="42-add-config",
-                repo="owner/repo",
-                config=make_config(),
-                checkpoint=make_checkpoint(),
-                issue_number=42,
-            )
-
-        assert result == "no_feedback"
-        mock_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1254,8 +1164,8 @@ class TestMonitorPrPrBeadWrites:
         assert first_call_bead.pr_number == 99
         assert first_call_bead.issue_number == 42
 
-    def test_does_not_dispatch_ci_fix(self) -> None:
-        """_dispatch_ci_fix_agent must NOT be called even when CI fails persistently."""
+    def test_returns_false_on_persistent_ci_failure(self) -> None:
+        """_monitor_pr returns False when CI fails persistently without recovery."""
         store = self._make_store()
         fail_checks = [{"name": "ci", "status": "completed", "conclusion": "failure"}]
 
@@ -1272,12 +1182,10 @@ class TestMonitorPrPrBeadWrites:
             patch("brimstone.cli._is_conflict_failure", return_value=False),
             patch("brimstone.cli._gh", side_effect=gh_side_effect),
             patch("brimstone.cli.logger.log_conductor_event"),
-            patch("brimstone.cli._dispatch_ci_fix_agent") as mock_ci_fix,
             patch("brimstone.cli.session.save"),
         ):
             result = _monitor_pr(**self._make_monitor_kwargs(store, max_polls=10))
 
-        mock_ci_fix.assert_not_called()
         assert result is False
 
     def test_writes_ci_failing_bead_on_persistent_ci_failure(self) -> None:
@@ -1384,17 +1292,36 @@ class TestMonitorPrPrBeadWrites:
 
 
 class TestResumeStaleIssuesWorktree:
-    def _make_stale_issue(self, number: int = 57) -> dict:
-        return {"number": number, "labels": [{"name": "stage/impl"}], "assignees": []}
+    def _make_store(self, issue_number: int = 57, milestone: str = "v1") -> MagicMock:
+        """Return a mock BeadStore with one claimed WorkBead."""
+        from brimstone.beads import WorkBead
+
+        bead = WorkBead(
+            v=1,
+            issue_number=issue_number,
+            title="Stale issue",
+            milestone=milestone,
+            stage="impl",
+            module="cli",
+            priority="P2",
+            state="claimed",
+            branch=f"{issue_number}-add-feature",
+        )
+        store = MagicMock()
+        store.list_work_beads.return_value = [bead]
+        store.read_pr_bead.return_value = None
+        store.write_pr_bead.return_value = None
+        store.read_work_bead.return_value = bead
+        store.write_work_bead.return_value = None
+        return store
 
     def test_creates_worktree_for_pr_when_repo_root_provided(self) -> None:
         """When repo_root is given and PR exists, _checkout_existing_branch_worktree is called."""
-        stale = self._make_stale_issue(57)
+        store = self._make_store(57, "v1")
         config = make_config()
         checkpoint = make_checkpoint()
 
         with (
-            patch("brimstone.cli._list_in_progress_issues", return_value=[stale]),
             patch("brimstone.cli._find_pr_for_issue", return_value=(64, "57-add-feature")),
             patch(
                 "brimstone.cli._checkout_existing_branch_worktree", return_value="/tmp/wt/57"
@@ -1411,6 +1338,7 @@ class TestResumeStaleIssuesWorktree:
                 config=config,
                 checkpoint=checkpoint,
                 repo_root="/repo",
+                store=store,
             )
 
         mock_checkout.assert_called_once_with("57-add-feature", "/repo")
@@ -1421,12 +1349,11 @@ class TestResumeStaleIssuesWorktree:
 
     def test_cleans_up_worktree_after_monitoring_raises(self) -> None:
         """Worktree is removed even if _monitor_pr raises an exception."""
-        stale = self._make_stale_issue(57)
+        store = self._make_store(57, "v1")
         config = make_config()
         checkpoint = make_checkpoint()
 
         with (
-            patch("brimstone.cli._list_in_progress_issues", return_value=[stale]),
             patch("brimstone.cli._find_pr_for_issue", return_value=(64, "57-add-feature")),
             patch("brimstone.cli._checkout_existing_branch_worktree", return_value="/tmp/wt/57"),
             patch("brimstone.cli._monitor_pr", side_effect=RuntimeError("boom")),
@@ -1442,16 +1369,16 @@ class TestResumeStaleIssuesWorktree:
                     config=config,
                     checkpoint=checkpoint,
                     repo_root="/repo",
+                    store=store,
                 )
 
         mock_remove.assert_called_once_with("/tmp/wt/57", "/repo")
 
     def test_no_worktree_when_repo_root_empty(self) -> None:
         """When repo_root is empty, _checkout_existing_branch_worktree is not called."""
-        stale = self._make_stale_issue(57)
+        store = self._make_store(57, "v1")
 
         with (
-            patch("brimstone.cli._list_in_progress_issues", return_value=[stale]),
             patch("brimstone.cli._find_pr_for_issue", return_value=(64, "57-add-feature")),
             patch("brimstone.cli._checkout_existing_branch_worktree") as mock_checkout,
             patch("brimstone.cli._monitor_pr"),
@@ -1466,9 +1393,23 @@ class TestResumeStaleIssuesWorktree:
                 config=make_config(),
                 checkpoint=make_checkpoint(),
                 repo_root="",
+                store=store,
             )
 
         mock_checkout.assert_not_called()
+
+    def test_returns_early_when_store_is_none(self) -> None:
+        """When store is None, _resume_stale_issues returns an empty set immediately."""
+        result = _resume_stale_issues(
+            repo="owner/repo",
+            milestone="v1",
+            label="stage/impl",
+            log_prefix="[test]",
+            config=make_config(),
+            checkpoint=make_checkpoint(),
+            store=None,
+        )
+        assert result == set()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_research.py
+++ b/tests/unit/test_cli_research.py
@@ -1037,20 +1037,47 @@ class TestRunResearchWorkerDryRun:
 class TestResumeUnclaim:
     """Verify the resume block correctly handles stale in-progress issues."""
 
+    def _make_store(self, issue_numbers: list[int], milestone: str = "MVP Research") -> MagicMock:
+        """Return a mock BeadStore with claimed WorkBeads for each issue number."""
+        from brimstone.beads import WorkBead
+
+        beads = [
+            WorkBead(
+                v=1,
+                issue_number=n,
+                title=f"Issue {n}",
+                milestone=milestone,
+                stage="research",
+                module="cli",
+                priority="P2",
+                state="claimed",
+                branch=f"{n}-stale-branch",
+            )
+            for n in issue_numbers
+        ]
+        store = MagicMock()
+        store.list_work_beads.return_value = beads
+        store.read_pr_bead.return_value = None
+        store.write_pr_bead.return_value = None
+        store.read_work_bead.return_value = beads[0] if beads else None
+        store.write_work_bead.return_value = None
+        store.read_merge_queue.return_value = MagicMock(queue=[])
+        store.write_merge_queue.return_value = None
+        store.flush.return_value = None
+        return store
+
     def test_stale_issue_with_pr_is_monitored(self, tmp_path: Path) -> None:
         """In-progress issue that already has an open PR is resumed via _monitor_pr."""
         config = make_config()
         object.__setattr__(config, "checkpoint_dir", tmp_path)
         object.__setattr__(config, "log_dir", tmp_path / "logs")
         checkpoint = make_checkpoint()
-
-        stale = make_issue(42, title="Stale with PR")
+        store = self._make_store([42])
 
         monitor_calls: list[int] = []
         unclaim_calls: list[int] = []
 
         with (
-            patch("brimstone.cli._list_in_progress_issues", return_value=[stale]),
             patch("brimstone.cli._find_pr_for_issue", return_value=(99, "42-stale-branch")),
             patch(
                 "brimstone.cli._monitor_pr",
@@ -1073,6 +1100,7 @@ class TestResumeUnclaim:
                 config=config,
                 checkpoint=checkpoint,
                 dry_run=False,
+                store=store,
             )
 
         assert 99 in monitor_calls, "_monitor_pr should be called for issue with PR"
@@ -1084,15 +1112,14 @@ class TestResumeUnclaim:
         object.__setattr__(config, "checkpoint_dir", tmp_path)
         object.__setattr__(config, "log_dir", tmp_path / "logs")
         checkpoint = make_checkpoint()
-
-        stale = make_issue(77, title="Stale no PR")
+        store = self._make_store([77])
 
         unclaim_calls: list[int] = []
         monitor_calls: list[int] = []
 
         with (
-            patch("brimstone.cli._list_in_progress_issues", return_value=[stale]),
             patch("brimstone.cli._find_pr_for_issue", return_value=None),
+            patch("brimstone.cli._pr_merged_for_issue", return_value=False),
             patch(
                 "brimstone.cli._unclaim_issue",
                 side_effect=lambda repo, issue_number, **kw: unclaim_calls.append(issue_number),
@@ -1114,6 +1141,7 @@ class TestResumeUnclaim:
                 config=config,
                 checkpoint=checkpoint,
                 dry_run=False,
+                store=store,
             )
 
         assert 77 in unclaim_calls, "_unclaim_issue must be called for stale issue with no PR"
@@ -1125,9 +1153,7 @@ class TestResumeUnclaim:
         object.__setattr__(config, "checkpoint_dir", tmp_path)
         object.__setattr__(config, "log_dir", tmp_path / "logs")
         checkpoint = make_checkpoint()
-
-        stale_with_pr = make_issue(10, title="Has PR")
-        stale_no_pr = make_issue(20, title="No PR")
+        store = self._make_store([10, 20])
 
         def fake_find_pr(repo: str, issue_number: int):
             if issue_number == 10:
@@ -1138,11 +1164,8 @@ class TestResumeUnclaim:
         unclaim_calls: list[int] = []
 
         with (
-            patch(
-                "brimstone.cli._list_in_progress_issues",
-                return_value=[stale_with_pr, stale_no_pr],
-            ),
             patch("brimstone.cli._find_pr_for_issue", side_effect=fake_find_pr),
+            patch("brimstone.cli._pr_merged_for_issue", return_value=False),
             patch(
                 "brimstone.cli._monitor_pr",
                 side_effect=lambda pr_number, **kw: monitor_calls.append(pr_number),
@@ -1163,6 +1186,7 @@ class TestResumeUnclaim:
                 config=config,
                 checkpoint=checkpoint,
                 dry_run=False,
+                store=store,
             )
 
         assert 55 in monitor_calls, "Issue 10 (has PR) should be monitored"


### PR DESCRIPTION
## Summary
- Removes 5 dead functions: `_list_in_progress_issues`, `_dispatch_ci_fix_agent`, `_collect_pr_review_context`, `_dismiss_stale_change_requests`, `_handle_pr_review_feedback` (~385 lines)
- Simplifies `_resume_stale_issues()`: removes GH API fallback (store=None early-return), store path is now unconditional
- Removes legacy checkpoint writes: `checkpoint.completed_prs.append()` and `checkpoint.open_prs[branch]`
- Updates tests: removes `TestHandlePrReviewFeedback`, rewrites `TestResumeStaleIssuesWorktree` and `TestResumeUnclaim` to use mock BeadStore instead of `_list_in_progress_issues` patches, updates integration tests similarly

## Test plan
- [x] 521 tests pass
- [x] `ruff check` clean
- [x] `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)