### PR TITLE
test(runner): assert --fallback-model absent when fallback equals primary model

### DIFF
--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -287,7 +287,7 @@ def test_assemble_command_fallback_model_absent_when_none() -> None:
 
 
 def test_assemble_command_fallback_model_absent_when_equals_model() -> None:
-    """When fallback_model equals model, --fallback-model is absent (claude rejects identical pairs)."""
+    """--fallback-model absent when fallback_model == model (claude rejects identical pairs)."""
     model = "claude-haiku-4-5-20251001"
     cmd = _assemble_command(
         prompt="x",

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -286,6 +286,20 @@ def test_assemble_command_fallback_model_absent_when_none() -> None:
     assert "--fallback-model" not in cmd
 
 
+def test_assemble_command_fallback_model_absent_when_equals_model() -> None:
+    """When fallback_model equals model, --fallback-model is absent (claude rejects identical pairs)."""
+    model = "claude-haiku-4-5-20251001"
+    cmd = _assemble_command(
+        prompt="x",
+        allowed_tools=["Bash"],
+        max_turns=10,
+        append_system_prompt_file=None,
+        model=model,
+        fallback_model=model,
+    )
+    assert "--fallback-model" not in cmd
+
+
 # ---------------------------------------------------------------------------
 # run() — dry-run
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix for #226 was already in `_assemble_command` (the `fallback_model != model` guard). This PR adds the missing unit test that verifies `--fallback-model` is absent when `fallback_model == model`.

Closes #226

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>