### PR TITLE
test: merge-queue drain, bead lifecycle, watchdog exhaustion + pipeline stage fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ brimstone — autonomous GitHub issue workstream orchestrator
 
 ## How It Works
 
-brimstone runs a four-stage pipeline (scope → research → design → impl) against a target
-GitHub repo by invoking Claude Code sub-agents in isolated git worktrees. Each stage reads
-the previous stage's output from GitHub issues and docs, then produces the next stage's input.
+brimstone runs a five-stage pipeline (plan → research → design → scope → impl) against a
+target GitHub repo by invoking Claude Code sub-agents in isolated git worktrees. Each stage
+reads the previous stage's output from GitHub issues and docs, then produces the next stage's
+input.
 Bead files (`~/.brimstone/beads/`) provide durable state so that the orchestrator survives
 restarts and rate-limit backoffs. A Watchdog loop detects zombie agents and dispatches recovery
 sub-agents automatically. A MergeQueue ensures sequential squash merges to keep the commit
@@ -31,11 +32,14 @@ uv sync
 ## Quick Start
 
 ```bash
-# Scope a milestone (decompose a spec into research issues)
-brimstone run --stage scope --repo OWNER/REPO --milestone v0.2.0
+# Run all stages from a spec file (milestone inferred from filename)
+brimstone run specs/v0.2.0-function-library.md --repo OWNER/REPO
 
-# Run the full impl pipeline (research + design handled separately first)
-brimstone run --stage impl --repo OWNER/REPO --milestone v0.2.0
+# Or run stages individually in order:
+brimstone run --stage research --repo OWNER/REPO --milestone v0.2.0
+brimstone run --stage design   --repo OWNER/REPO --milestone v0.2.0
+brimstone run --stage scope    --repo OWNER/REPO --milestone v0.2.0
+brimstone run --stage impl     --repo OWNER/REPO --milestone v0.2.0
 ```
 
 ## `--repo` Resolution

--- a/docs/design/HLD.md
+++ b/docs/design/HLD.md
@@ -7,22 +7,23 @@
 
 ## 1. System Overview
 
-brimstone is a Python CLI orchestrator that automates multi-stage GitHub issue workstreams using Claude Code in headless `-p` mode. It runs as a single orchestrator process (`brimstone run`) that coordinates isolated Claude Code sub-agents across four pipeline stages:
+brimstone is a Python CLI orchestrator that automates multi-stage GitHub issue workstreams using Claude Code in headless `-p` mode. It runs as a single orchestrator process (`brimstone run`) that coordinates isolated Claude Code sub-agents across five pipeline stages:
 
 ```
-scope → research → design → impl
+plan → research → design → scope → impl
 ```
 
 | Stage | Entry point | Produces |
 |-------|-------------|---------|
-| `scope` | `brimstone run --stage scope` | `stage/research` GitHub issues decomposed from a spec |
+| `plan` | `brimstone run --stage plan` | GitHub milestone + `stage/research` issues seeded from spec |
 | `research` | `brimstone run --stage research` | `docs/research/<N>-<slug>.md` per issue |
 | `design` | `brimstone run --stage design` | `docs/design/HLD.md` + `docs/design/lld/<module>.md` |
+| `scope` | `brimstone run --stage scope` | `stage/impl` issues decomposed from HLD/LLD docs |
 | `impl` | `brimstone run --stage impl` | Merged PRs, working code |
 
 Each stage's output is the next stage's input. Design and issue decomposition are explicitly separated: the design stage produces design documents; scope decomposes those into actionable GitHub issues.
 
-**What it is not:** brimstone is not a general-purpose AI agent framework. It is purpose-built for the workstream: scope → research → design → implement.
+**What it is not:** brimstone is not a general-purpose AI agent framework. It is purpose-built for the workstream: plan → research → design → scope → implement.
 
 ---
 

--- a/tests/integration/test_merge_and_recovery.py
+++ b/tests/integration/test_merge_and_recovery.py
@@ -122,9 +122,7 @@ def _make_work_bead(
 class TestMonitorPrToMergeQueueDrain:
     """_monitor_pr enqueues; _process_merge_queue drains and updates beads."""
 
-    def test_happy_path_bead_states_after_drain(
-        self, git_repo: Path, tmp_path: Path
-    ) -> None:
+    def test_happy_path_bead_states_after_drain(self, git_repo: Path, tmp_path: Path) -> None:
         """Full happy path: CI passes → enqueued → squash-merged → beads closed.
 
         _monitor_pr writes a PRBead and enqueues a MergeQueueEntry.
@@ -213,9 +211,7 @@ class TestMonitorPrToMergeQueueDrain:
             f"WorkBead.state must be 'closed', got {work_bead_after.state!r}"
         )
 
-    def test_merge_failure_leaves_pr_bead_unchanged(
-        self, git_repo: Path, tmp_path: Path
-    ) -> None:
+    def test_merge_failure_leaves_pr_bead_unchanged(self, git_repo: Path, tmp_path: Path) -> None:
         """If squash-merge fails, PRBead state is not updated and queue is cleared."""
         os.chdir(git_repo)
         config = make_config(tmp_path)

--- a/tests/integration/test_merge_and_recovery.py
+++ b/tests/integration/test_merge_and_recovery.py
@@ -122,7 +122,9 @@ def _make_work_bead(
 class TestMonitorPrToMergeQueueDrain:
     """_monitor_pr enqueues; _process_merge_queue drains and updates beads."""
 
-    def test_happy_path_bead_states_after_drain(self, git_repo: Path, tmp_path: Path) -> None:
+    def test_happy_path_bead_states_after_drain(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
         """Full happy path: CI passes → enqueued → squash-merged → beads closed.
 
         _monitor_pr writes a PRBead and enqueues a MergeQueueEntry.
@@ -211,7 +213,9 @@ class TestMonitorPrToMergeQueueDrain:
             f"WorkBead.state must be 'closed', got {work_bead_after.state!r}"
         )
 
-    def test_merge_failure_leaves_pr_bead_unchanged(self, git_repo: Path, tmp_path: Path) -> None:
+    def test_merge_failure_leaves_pr_bead_unchanged(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
         """If squash-merge fails, PRBead state is not updated and queue is cleared."""
         os.chdir(git_repo)
         config = make_config(tmp_path)
@@ -294,8 +298,7 @@ class TestImplWorkerBeadLifecycle:
 
         store.write_work_bead = spy_write_work_bead  # type: ignore[method-assign]
 
-        # _dispatch_impl_agent is called in a ThreadPoolExecutor; its return value
-        # is unpacked as (issue, branch, worktree_path, result).
+        # _dispatch_impl_agent returns (issue, branch, worktree_path, result)
         def fake_dispatch(
             issue: dict,
             branch: str,
@@ -428,14 +431,8 @@ class TestWatchdogScanExhaustion:
         work_bead = _make_work_bead(issue_number=7, state="claimed", claimed_at=old_claim)
         store.write_work_bead(work_bead)
 
-        # _unclaim_issue calls _gh(["issue", "view", ..., "--json", "assignees"])
-        # and parses stdout as JSON — provide a real string to avoid MagicMock errors.
-        gh_result = MagicMock()
-        gh_result.returncode = 0
-        gh_result.stdout = '{"assignees": []}'
-
         with (
-            patch("brimstone.cli._gh", return_value=gh_result),
+            patch("brimstone.cli._gh", side_effect=_gh_side_effect),
             patch("brimstone.cli.logger.log_conductor_event"),
             patch("brimstone.cli.session.save"),
         ):


### PR DESCRIPTION
## Summary

- Adds integration tests for three critical previously-untested flows (step 2 of the confidence plan)
- Fixes a real bug discovered by the watchdog exhaustion test
- Fixes wrong pipeline stage order in README and HLD

## Tests added (`tests/integration/test_merge_and_recovery.py`)

1. **`TestMonitorPrToMergeQueueDrain`** — `_monitor_pr` enqueues an entry, `_process_merge_queue` drains it, `PRBead.state='merged'` and `WorkBead.state='closed'` after success; merge failure leaves bead state unchanged.

2. **`TestImplWorkerBeadLifecycle`** — `WorkBead(state='claimed')` is written before `_dispatch_impl_agent` is called; claim happens before dispatch (ordering invariant).

3. **`TestWatchdogScanExhaustion`** — zombie with `fix_attempts >= WATCHDOG_MAX_FIX_ATTEMPTS` and old `claimed_at` is exhausted (`WorkBead.state='abandoned'`); active issues and recently-claimed issues are not touched.

## Bug fix (`src/brimstone/cli.py`)

`_unclaim_issue` was unconditionally setting `WorkBead.state = "open"`, clobbering `"abandoned"` written by `_exhaust_issue`. Guard added: skip bead update if state is already `"abandoned"` or `"closed"`.

## Docs fix

README and `docs/design/HLD.md` both said `scope → research → design → impl` (wrong order, missing `plan`). Corrected to `plan → research → design → scope → impl` with updated Quick Start examples.

## Test plan
- [x] `uv run pytest tests/integration/test_merge_and_recovery.py` — 7 passed
- [x] `uv run ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)