### PR TITLE
feat(cli): brimstone cost + brimstone report commands

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -4973,18 +4973,288 @@ def health_cmd(repo: str | None, as_json: bool) -> None:
 
 
 @brimstone.command("cost")
-def cost() -> None:
-    """Show cost ledger summary."""
+@click.option("--run", "run_id", default=None, help="Filter by run ID")
+@click.option(
+    "--stage",
+    default=None,
+    help="Filter by stage (research/design/scope/impl)",
+)
+@click.option("--repo", default=None, help="Filter by repo (owner/name)")
+@click.option("--milestone", default=None, help="Filter by milestone")
+@click.option(
+    "--breakdown",
+    type=click.Choice(["run", "stage", "model", "issue"]),
+    default=None,
+    help="Group results by this field",
+)
+def cost(
+    run_id: str | None,
+    stage: str | None,
+    repo: str | None,
+    milestone: str | None,
+    breakdown: str | None,
+) -> None:
+    """Show cost summary from the cost ledger."""
     config = load_config()
-    checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
-    _chk = session.load(checkpoint_path)
-    _config, _checkpoint, _store = startup_sequence(
-        config=config,
-        checkpoint_path=checkpoint_path,
-        milestone="",
-        stage="cost",
-    )
-    click.echo("Not yet implemented")
+    log_dir = config.log_dir.expanduser()
+
+    entries = logger.read_cost_ledger(log_dir, repo=repo, stage=stage)
+
+    # Apply additional filters in Python
+    if run_id is not None:
+        entries = [e for e in entries if e.get("run_id") == run_id]
+    if milestone is not None:
+        entries = [e for e in entries if e.get("milestone") == milestone]
+
+    if not entries:
+        click.echo("No cost data found.")
+        return
+
+    def _total_cost(ents: list[dict]) -> float:
+        return sum(e.get("total_cost_usd") or 0 for e in ents)
+
+    def _total_input(ents: list[dict]) -> int:
+        return sum(e.get("input_tokens") or 0 for e in ents)
+
+    def _total_output(ents: list[dict]) -> int:
+        return sum(e.get("output_tokens") or 0 for e in ents)
+
+    click.echo("Cost summary")
+    click.echo(f"  Entries : {len(entries)}")
+    click.echo(f"  Total   : ${_total_cost(entries):.4f}")
+    click.echo(f"  Input   : {_total_input(entries):,} tokens")
+    click.echo(f"  Output  : {_total_output(entries):,} tokens")
+
+    if breakdown:
+        # Group by the breakdown field
+        groups: dict[str, list[dict]] = {}
+        for e in entries:
+            key = str(e.get(breakdown) or "(unknown)")
+            groups.setdefault(key, []).append(e)
+
+        click.echo(f"\n  By {breakdown}:")
+        for key, group_entries in sorted(groups.items()):
+            n = len(group_entries)
+            click.echo(f"  {key:<12}  ${_total_cost(group_entries):.4f}  {n:>4} calls")
+
+
+@brimstone.command("report")
+@click.option("--repo", default=None)
+@click.option("--run", "run_id", default=None, help="Run ID (defaults to most recent)")
+@click.option("--milestone", default=None)
+@click.option(
+    "--post",
+    is_flag=True,
+    default=False,
+    help="Post report as GitHub issue comment",
+)
+def report(
+    repo: str | None,
+    run_id: str | None,
+    milestone: str | None,
+    post: bool,
+) -> None:
+    """Print a session report from BeadStore and cost ledger."""
+    config = load_config()
+    repo_ref = repo or config.github_repo
+    if not repo_ref:
+        click.echo("Error: --repo is required (or set github_repo in config)", err=True)
+        raise SystemExit(1)
+    _print_session_report(config, repo_ref, run_id, milestone, post)
+
+
+def _print_session_report(
+    config: Config,
+    repo: str,
+    run_id: str | None,
+    milestone: str | None,
+    post: bool,
+) -> None:
+    """Render a session report from BeadStore and cost ledger."""
+    log_dir = config.log_dir.expanduser()
+    store = make_bead_store(config, repo)
+
+    # Load cost entries
+    all_cost_entries = logger.read_cost_ledger(log_dir, repo=repo)
+    if milestone is not None:
+        all_cost_entries = [e for e in all_cost_entries if e.get("milestone") == milestone]
+
+    # Resolve run_id from most recent cost entry if not specified
+    effective_run_id = run_id
+    if effective_run_id is None and all_cost_entries:
+        effective_run_id = all_cost_entries[-1].get("run_id")
+
+    if effective_run_id is not None:
+        cost_entries = [e for e in all_cost_entries if e.get("run_id") == effective_run_id]
+    else:
+        cost_entries = all_cost_entries
+
+    total_cost = sum(e.get("total_cost_usd") or 0 for e in cost_entries)
+
+    # Load beads
+    work_beads = store.list_work_beads()
+    pr_beads = store.list_pr_beads()
+
+    # Filter by milestone if provided
+    if milestone is not None:
+        work_beads = [b for b in work_beads if b.milestone == milestone]
+
+    sep = "═" * 54
+    click.echo(sep)
+    click.echo("  brimstone session report")
+    header_parts = [f"Repo: {repo}"]
+    if milestone:
+        header_parts.append(f"Milestone: {milestone}")
+    click.echo(f"  {'  |  '.join(header_parts)}")
+    run_label = effective_run_id if effective_run_id else "(unknown)"
+    click.echo(f"  Run: {run_label}  |  Cost: ${total_cost:.2f}")
+    click.echo(sep)
+
+    # ISSUES table
+    click.echo("")
+    click.echo("ISSUES")
+    if not work_beads:
+        click.echo("  (none)")
+    else:
+        for wb in sorted(work_beads, key=lambda b: b.issue_number):
+            pr_info = "(no PR yet)"
+            if wb.pr_id:
+                # pr_id is like "pr-187" — extract number
+                try:
+                    pr_num = int(wb.pr_id.split("-", 1)[1])
+                    pr_bead = store.read_pr_bead(pr_num)
+                    if pr_bead:
+                        pr_info = f"PR #{pr_num}  {pr_bead.state}"
+                    else:
+                        pr_info = f"PR #{pr_num}"
+                except (IndexError, ValueError):
+                    pr_info = wb.pr_id
+            click.echo(f"  #{wb.issue_number:<4}  {wb.title:<26}  {wb.state:<12}  {pr_info}")
+
+    # PULL REQUESTS table
+    click.echo("")
+    click.echo("PULL REQUESTS")
+    if not pr_beads:
+        click.echo("  (none)")
+    else:
+        # Build per-PR cost map
+        pr_cost_map: dict[int, float] = {}
+        for e in cost_entries:
+            issue_num = e.get("issue_number")
+            if issue_num is None:
+                continue
+            # Find PR bead linked to this issue
+            for pb in pr_beads:
+                if pb.issue_number == issue_num:
+                    prev = pr_cost_map.get(pb.pr_number, 0.0)
+                    pr_cost_map[pb.pr_number] = prev + (e.get("total_cost_usd") or 0)
+
+        for pb in sorted(pr_beads, key=lambda b: b.pr_number):
+            pr_cost = pr_cost_map.get(pb.pr_number, 0.0)
+            fix_info = f"{pb.fix_attempts} fix attempts"
+            click.echo(
+                f"  PR #{pb.pr_number:<4}  {pb.branch:<20}"
+                f"  {pb.state:<14}  ${pr_cost:.2f}   {fix_info}"
+            )
+
+    # SUMMARY
+    click.echo("")
+    click.echo("SUMMARY")
+    state_counts: dict[str, int] = {}
+    for wb in work_beads:
+        state_counts[wb.state] = state_counts.get(wb.state, 0) + 1
+    issue_parts = [f"{cnt} {st}" for st, cnt in sorted(state_counts.items())]
+    issue_summary = "  |  ".join(issue_parts) if issue_parts else "(none)"
+    click.echo(f"  Issues:  {issue_summary}")
+
+    pr_state_counts: dict[str, int] = {}
+    for pb in pr_beads:
+        pr_state_counts[pb.state] = pr_state_counts.get(pb.state, 0) + 1
+    pr_parts = [f"{cnt} {st}" for st, cnt in sorted(pr_state_counts.items())]
+    pr_summary = "  |  ".join(pr_parts) if pr_parts else "(none)"
+    click.echo(f"  PRs:     {pr_summary}")
+    click.echo(f"  Cost:    ${total_cost:.2f} total")
+    click.echo(sep)
+
+    if post and milestone:
+        import subprocess as _subprocess
+
+        gh_result = _subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--milestone",
+                milestone,
+                "--label",
+                "roadmap",
+                "--json",
+                "number",
+                "--limit",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        issue_list: list[dict] = []
+        try:
+            import json as _json
+
+            issue_list = _json.loads(gh_result.stdout or "[]")
+        except Exception:
+            issue_list = []
+
+        if not issue_list:
+            click.echo(
+                f"Warning: no roadmap tracking issue found for milestone "
+                f"{milestone!r}; skipping post.",
+                err=True,
+            )
+        else:
+            tracking_issue_number = issue_list[0]["number"]
+            # Build markdown body
+            run_md = effective_run_id or "(unknown)"
+            md_lines = [
+                "## brimstone session report",
+                (
+                    f"**Repo:** {repo}  |  **Milestone:** {milestone}"
+                    f"  |  **Run:** {run_md}  |  **Cost:** ${total_cost:.2f}"
+                ),
+                "",
+                "### Issues",
+                "| # | Title | State | PR |",
+                "|---|-------|-------|----|",
+            ]
+            for wb in sorted(work_beads, key=lambda b: b.issue_number):
+                pr_col = ""
+                if wb.pr_id:
+                    try:
+                        pr_num = int(wb.pr_id.split("-", 1)[1])
+                        pr_bead = store.read_pr_bead(pr_num)
+                        pr_col = f"PR #{pr_num} {pr_bead.state if pr_bead else ''}"
+                    except (IndexError, ValueError):
+                        pr_col = wb.pr_id
+                md_lines.append(f"| #{wb.issue_number} | {wb.title} | {wb.state} | {pr_col} |")
+
+            md_lines += ["", "### Summary", f"- Cost: ${total_cost:.2f}", ""]
+            body = "\n".join(md_lines)
+
+            _subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "comment",
+                    str(tracking_issue_number),
+                    "--repo",
+                    repo,
+                    "--body",
+                    body,
+                ],
+                capture_output=True,
+                text=True,
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -5460,6 +5730,22 @@ def run(
                             )
                             time.sleep(BACKOFF_SLEEP_SECONDS)
                         click.echo(f"[campaign] {ms} fully shipped.", err=True)
+
+                # Print per-stage cost summary
+                try:
+                    _entries = logger.read_cost_ledger(
+                        _config.log_dir.expanduser(),
+                        repo=repo_ref or "",
+                        stage=stage,
+                    )
+                    if _entries:
+                        _stage_cost = sum(e.get("total_cost_usd") or 0 for e in _entries)
+                        click.echo(
+                            f"[{stage}] cost: ${_stage_cost:.4f} ({len(_entries)} calls)",
+                            err=True,
+                        )
+                except AttributeError:
+                    pass
 
         # Mark milestone as shipped in campaign bead
         if is_campaign and not dry_run and campaign_store is not None:

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -1857,3 +1857,80 @@ class TestWatchdogScan:
             )
 
         mock_dispatch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# End-of-run cost summary
+# ---------------------------------------------------------------------------
+
+
+class TestEndOfRunCostSummary:
+    """After each worker completes, the run command prints a cost summary line."""
+
+    def test_end_of_run_cost_summary_printed(self, tmp_path: Path) -> None:
+        """After impl worker completes, a cost summary line is echoed to stderr."""
+        import json as _json
+
+        from click.testing import CliRunner
+
+        from brimstone.cli import composer
+
+        _REPO = "owner/repo"
+        _MILESTONE = "v1.0"
+
+        # Prepare a log dir with a cost entry for the "impl" stage
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        cost_entry = {
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "session_id": "sess-1",
+            "run_id": "run-1",
+            "repo": _REPO,
+            "milestone": _MILESTONE,
+            "stage": "impl",
+            "issue_number": 1,
+            "model": "claude-sonnet-4-6",
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "num_turns": 3,
+            "duration_ms": 5000,
+            "is_error": False,
+            "error_subtype": None,
+            "total_cost_usd": 0.25,
+            "auth_mode": "api_key",
+            "web_search_requests": 0,
+        }
+        (log_dir / "cost.jsonl").write_text(_json.dumps(cost_entry) + "\n")
+
+        # Build a config-like object; override log_dir to use the temp path
+        config = make_config()
+        object.__setattr__(config, "log_dir", log_dir)
+        checkpoint = make_checkpoint()
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("brimstone.cli._resolve_repo", return_value=_REPO),
+                patch("brimstone.cli._milestone_exists", return_value=True),
+                patch(
+                    "brimstone.cli._get_default_branch_for_repo",
+                    return_value="main",
+                ),
+                patch("brimstone.cli._count_open_issues_by_label", return_value=2),
+                patch("brimstone.cli._ensure_labels"),
+                patch(
+                    "brimstone.cli.startup_sequence",
+                    return_value=(config, checkpoint, MagicMock()),
+                ),
+                patch("brimstone.cli._run_impl_worker"),
+            ):
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["run", "--impl", "--repo", _REPO, "--milestone", _MILESTONE],
+                )
+
+        assert result.exit_code == 0, result.output
+        # click.echo(..., err=True) still appears in result.output for CliRunner
+        assert "[impl] cost:" in result.output

--- a/tests/unit/test_cost_cmd.py
+++ b/tests/unit/test_cost_cmd.py
@@ -1,0 +1,266 @@
+"""Unit tests for the `brimstone cost` and `brimstone report` commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from brimstone.cli import composer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_ENV = {
+    "ANTHROPIC_API_KEY": "sk-ant-test-key",
+    "BRIMSTONE_GH_TOKEN": "ghp-test-token",
+}
+
+
+def _write_cost_entries(log_dir: Path, entries: list[dict]) -> None:
+    """Write JSONL cost entries to {log_dir}/cost.jsonl."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    cost_path = log_dir / "cost.jsonl"
+    with cost_path.open("w") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def _make_cost_entry(
+    *,
+    run_id: str = "run-abc",
+    repo: str = "owner/repo",
+    stage: str = "impl",
+    milestone: str = "v1.0",
+    total_cost_usd: float = 0.10,
+    input_tokens: int = 1000,
+    output_tokens: int = 500,
+) -> dict:
+    return {
+        "timestamp": "2026-01-01T00:00:00+00:00",
+        "session_id": "sess-1",
+        "run_id": run_id,
+        "repo": repo,
+        "milestone": milestone,
+        "stage": stage,
+        "issue_number": 1,
+        "model": "claude-sonnet-4-6",
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "num_turns": 3,
+        "duration_ms": 5000,
+        "is_error": False,
+        "error_subtype": None,
+        "total_cost_usd": total_cost_usd,
+        "auth_mode": "api_key",
+        "web_search_requests": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# brimstone cost
+# ---------------------------------------------------------------------------
+
+
+class TestCostCommand:
+    def test_cost_no_data(self, tmp_path: Path) -> None:
+        """cost command with empty ledger prints 'No cost data found.'"""
+        # log_dir has no cost.jsonl at all
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("brimstone.cli.load_config") as mock_config:
+                cfg = MagicMock()
+                cfg.log_dir = tmp_path
+                mock_config.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["cost"])
+
+        assert result.exit_code == 0, result.output
+        assert "No cost data found." in result.output
+
+    def test_cost_totals(self, tmp_path: Path) -> None:
+        """cost command with 3 entries sums correctly."""
+        log_dir = tmp_path / "logs"
+        entries = [
+            _make_cost_entry(total_cost_usd=0.10, input_tokens=1000, output_tokens=200),
+            _make_cost_entry(total_cost_usd=0.20, input_tokens=2000, output_tokens=400),
+            _make_cost_entry(total_cost_usd=0.30, input_tokens=3000, output_tokens=600),
+        ]
+        _write_cost_entries(log_dir, entries)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("brimstone.cli.load_config") as mock_config:
+                cfg = MagicMock()
+                cfg.log_dir = log_dir
+                mock_config.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["cost"])
+
+        assert result.exit_code == 0, result.output
+        assert "Entries : 3" in result.output
+        assert "$0.6000" in result.output
+        assert "6,000" in result.output  # total input tokens
+        assert "1,200" in result.output  # total output tokens
+
+    def test_cost_breakdown_by_stage(self, tmp_path: Path) -> None:
+        """--breakdown stage groups entries correctly."""
+        log_dir = tmp_path / "logs"
+        entries = [
+            _make_cost_entry(stage="research", total_cost_usd=0.10),
+            _make_cost_entry(stage="research", total_cost_usd=0.05),
+            _make_cost_entry(stage="impl", total_cost_usd=0.30),
+        ]
+        _write_cost_entries(log_dir, entries)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("brimstone.cli.load_config") as mock_config:
+                cfg = MagicMock()
+                cfg.log_dir = log_dir
+                mock_config.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["cost", "--breakdown", "stage"])
+
+        assert result.exit_code == 0, result.output
+        assert "By stage" in result.output
+        assert "research" in result.output
+        assert "impl" in result.output
+        # research total is 0.15, impl is 0.30
+        assert "0.1500" in result.output
+        assert "0.3000" in result.output
+
+    def test_cost_filter_by_run_id(self, tmp_path: Path) -> None:
+        """--run filters to only that run_id."""
+        log_dir = tmp_path / "logs"
+        entries = [
+            _make_cost_entry(run_id="run-x", total_cost_usd=0.10),
+            _make_cost_entry(run_id="run-y", total_cost_usd=0.99),
+        ]
+        _write_cost_entries(log_dir, entries)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("brimstone.cli.load_config") as mock_config:
+                cfg = MagicMock()
+                cfg.log_dir = log_dir
+                mock_config.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["cost", "--run", "run-x"])
+
+        assert result.exit_code == 0, result.output
+        assert "Entries : 1" in result.output
+        assert "$0.1000" in result.output
+        assert "0.9900" not in result.output
+
+    def test_cost_filter_by_milestone(self, tmp_path: Path) -> None:
+        """--milestone filters to only entries for that milestone."""
+        log_dir = tmp_path / "logs"
+        entries = [
+            _make_cost_entry(milestone="v1.0", total_cost_usd=0.10),
+            _make_cost_entry(milestone="v2.0", total_cost_usd=0.99),
+        ]
+        _write_cost_entries(log_dir, entries)
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("brimstone.cli.load_config") as mock_config:
+                cfg = MagicMock()
+                cfg.log_dir = log_dir
+                mock_config.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["cost", "--milestone", "v1.0"])
+
+        assert result.exit_code == 0, result.output
+        assert "Entries : 1" in result.output
+        assert "$0.1000" in result.output
+
+
+# ---------------------------------------------------------------------------
+# brimstone report
+# ---------------------------------------------------------------------------
+
+
+class TestReportCommand:
+    def test_report_no_beads(self, tmp_path: Path) -> None:
+        """report with empty BeadStore prints header + empty tables."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        mock_store = MagicMock()
+        mock_store.list_work_beads.return_value = []
+        mock_store.list_pr_beads.return_value = []
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("brimstone.cli.load_config") as mock_cfg,
+                patch("brimstone.cli.make_bead_store", return_value=mock_store),
+            ):
+                cfg = MagicMock()
+                cfg.log_dir = log_dir
+                cfg.github_repo = "owner/repo"
+                mock_cfg.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["report", "--repo", "owner/repo"])
+
+        assert result.exit_code == 0, result.output
+        assert "brimstone session report" in result.output
+        assert "ISSUES" in result.output
+        assert "PULL REQUESTS" in result.output
+        assert "SUMMARY" in result.output
+        assert "(none)" in result.output
+
+    def test_report_no_repo_shows_error(self, tmp_path: Path) -> None:
+        """report without --repo and no config github_repo shows error."""
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with patch("brimstone.cli.load_config") as mock_cfg:
+                cfg = MagicMock()
+                cfg.log_dir = tmp_path
+                cfg.github_repo = None
+                mock_cfg.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(composer, ["report"])
+
+        assert result.exit_code != 0
+
+    def test_report_with_cost_entries(self, tmp_path: Path) -> None:
+        """report shows cost total from ledger."""
+        log_dir = tmp_path / "logs"
+        entries = [
+            _make_cost_entry(
+                run_id="run-test",
+                repo="owner/repo",
+                total_cost_usd=0.42,
+            )
+        ]
+        _write_cost_entries(log_dir, entries)
+
+        mock_store = MagicMock()
+        mock_store.list_work_beads.return_value = []
+        mock_store.list_pr_beads.return_value = []
+
+        with patch.dict("os.environ", MINIMAL_ENV, clear=False):
+            with (
+                patch("brimstone.cli.load_config") as mock_cfg,
+                patch("brimstone.cli.make_bead_store", return_value=mock_store),
+            ):
+                cfg = MagicMock()
+                cfg.log_dir = log_dir
+                cfg.github_repo = "owner/repo"
+                mock_cfg.return_value = cfg
+
+                runner = CliRunner()
+                result = runner.invoke(
+                    composer,
+                    ["report", "--repo", "owner/repo", "--run", "run-test"],
+                )
+
+        assert result.exit_code == 0, result.output
+        assert "$0.42" in result.output


### PR DESCRIPTION
## Summary

- Replaces the `brimstone cost` stub with a full implementation: reads `cost.jsonl` via `logger.read_cost_ledger`, applies `--run`/`--milestone` filters in Python, supports `--breakdown` by run/stage/model/issue
- Adds `brimstone report` command: renders a session report from BeadStore (issues + PR tables) and the cost ledger; supports `--post` to comment on a milestone roadmap tracking issue
- Adds per-stage cost summary line printed to stderr after each worker completes in `brimstone run`
- Adds `tests/unit/test_cost_cmd.py` with 8 tests; extends `test_cli_impl.py` with `TestEndOfRunCostSummary`

## Test plan

- [ ] `uv run pytest` — 531 tests pass
- [ ] `uv run ruff check src/ tests/` — clean
- [ ] `uv run ruff format --check src/ tests/` — clean
- [ ] `brimstone cost` with empty ledger prints "No cost data found."
- [ ] `brimstone cost --breakdown stage` groups entries by stage
- [ ] `brimstone report --repo owner/repo` renders header + ISSUES + PULL REQUESTS + SUMMARY
- [ ] After `brimstone run --impl`, a `[impl] cost: $X.XXXX (N calls)` line appears on stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)