### PR TITLE
fix(impl): add summary + test plan template to impl PR body

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -3680,7 +3680,10 @@ def _dispatch_impl_agent(
         f"7. Commit with message referencing the issue\n"
         f"8. git push -u origin {branch}\n"
         f'9. Create PR: gh pr create --repo {repo} --title "{issue_title}" '
-        f'--label "{feat_label}" --body "Closes #{issue_number}"\n'
+        f'--label "{feat_label}" '
+        f'--body "Closes #{issue_number}\\n\\n'
+        f"## Summary\\n<1-3 sentences: what was implemented and key decisions>\\n\\n"
+        f'## Test plan\\n<bullet list of what was tested>"\n'
         f"10. After `gh pr create`, poll CI (max 60 attempts × 30s = 30 min):\n"
         f"    Loop: gh pr checks <PR-number> --json name,bucket --jq '[.[] | {{name,bucket}}]'\n"
         f"    Wait 30s between polls: sleep 30\n"


### PR DESCRIPTION
Impl worker PRs were created with body `Closes #N` only. Adds `## Summary` and `## Test plan` template sections to the `gh pr create` instruction in the impl agent prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)