### PR TITLE
fix(init): add 'infra' to required labels; ensure before scaffold

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -3924,6 +3924,22 @@ def _ensure_impl_scaffold(
         None,
     )
     if scaffold is None:
+        # Ensure `infra` label exists (may be absent in repos initialized before it
+        # was added to _REQUIRED_LABELS).
+        _gh(
+            [
+                "label",
+                "create",
+                "infra",
+                "--color",
+                "bfd4f2",
+                "--description",
+                "Infrastructure and tooling work",
+                "--force",
+            ],
+            repo=repo,
+            check=False,
+        )
         create = _gh(
             [
                 "issue",
@@ -5274,6 +5290,7 @@ _REQUIRED_LABELS: list[tuple[str, str, str]] = [
     ("wont-research", "eeeeee", "Closed by orchestrator — out of scope or duplicate"),
     ("pipeline", "006b75", "Pipeline stage transition tracking"),
     ("bug", "ee0701", "Defect filed by QA or reported post-release"),
+    ("infra", "bfd4f2", "Infrastructure and tooling work"),
 ]
 
 


### PR DESCRIPTION
## Summary
- Add `infra` label to `_REQUIRED_LABELS` so `brimstone init` creates it on new repos
- In `_ensure_impl_scaffold`, create the label idempotently with `--force` before filing the scaffold issue
- Fixes: `Warning: could not create scaffold issue: could not add label: 'infra' not found` on repos initialized before this label was added

## Test plan
- [ ] `make test` passes
- [ ] Run `brimstone run --all` against calculator repo — scaffold issue creates without warning