### PR TITLE
fix(resume): fall back to existing local branch when worktree checkout fails

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -3523,6 +3523,14 @@ def _checkout_existing_branch_worktree(branch: str, repo_root: str) -> str | Non
         capture_output=True,
         text=True,
     )
+    if result.returncode != 0 and "already exists" in result.stderr:
+        # Local branch exists from a previous session — check it out directly.
+        result = subprocess.run(
+            ["git", "worktree", "add", worktree_dir, branch],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
     return worktree_dir if result.returncode == 0 else None
 
 


### PR DESCRIPTION
## Summary
- `_checkout_existing_branch_worktree` used `git worktree add -b branch` which fails if a local branch already exists from a previous session
- This left `worktree_path` empty, causing `_monitor_pr` to log "conflict detected but no worktree" and return without resolving
- Root cause for PR #35 (calculator) not being picked up despite conflict detection running

## Fix
Add fallback: if `-b` fails with "already exists", retry without `-b` to check out the existing local branch.

## Test plan
- [ ] `make test` passes
- [ ] Re-run `brimstone run --all` against calculator — PR #35 should get conflict-resolved and merged