### PR TITLE
fix(gates): design gate sees in-progress research; research _when_empty drains merge queue

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -880,6 +880,40 @@ def _list_open_issues_by_label(repo: str, milestone: str, label: str) -> list[di
     ]
 
 
+def _list_all_open_issues_by_label(repo: str, milestone: str, label: str) -> list[dict[str, Any]]:
+    """Return ALL open issues for a stage label — including in-progress ones.
+
+    Unlike ``_list_open_issues_by_label``, this does NOT filter by assignee or
+    ``in-progress`` label. Used by progress gates that need to block until every
+    issue of a stage is actually closed (merged), not just until they've been
+    claimed and dispatched.
+    """
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--label",
+            label,
+            "--milestone",
+            milestone,
+            "--json",
+            "number,title,body,labels,assignees,milestone",
+            "--limit",
+            "200",
+        ],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
 def _seed_work_beads(
     repo: str,
     milestone: str,
@@ -2162,9 +2196,50 @@ def _run_research_worker(
                         dry_run=False,
                     )
                     return True
+                # All blocking beads are in merge_ready state — their PRs are
+                # queued but not yet merged. Drain the merge queue now so the
+                # research loop doesn't stall out and exit prematurely.
+                if all(b.state == "merge_ready" for b in blocking):
+                    _process_merge_queue(
+                        repo=repo,
+                        config=config,
+                        checkpoint=checkpoint,
+                        store=store,
+                        default_branch=default_branch,
+                        repo_root=repo_root,
+                    )
+                    # Re-check after draining
+                    all_beads = store.list_work_beads(milestone=milestone, stage="research")
+                    open_beads = [b for b in all_beads if b.state not in ("closed", "abandoned")]
+                    if not open_beads:
+                        _run_completion_gate(
+                            repo=repo,
+                            milestone=milestone,
+                            open_issues=[],
+                            config=config,
+                            checkpoint=checkpoint,
+                            dry_run=False,
+                        )
+                        return True
+                    blocking = [b for b in open_beads if not b.deferred]
+                    if not blocking:
+                        deferred_issues = [
+                            {"number": b.issue_number, "title": b.title} for b in open_beads
+                        ]
+                        _run_completion_gate(
+                            repo=repo,
+                            milestone=milestone,
+                            open_issues=deferred_issues,
+                            config=config,
+                            checkpoint=checkpoint,
+                            dry_run=False,
+                        )
+                        return True
                 return False
-            # Fallback: no bead store — use GitHub-based completion check
-            open_issues = _list_open_issues_by_label(repo, milestone, RESEARCH_LABEL)
+            # Fallback: no bead store — use GitHub-based completion check.
+            # Use _list_all_open_issues_by_label so in-progress issues (claimed,
+            # PR open but not merged) are not silently excluded.
+            open_issues = _list_all_open_issues_by_label(repo, milestone, RESEARCH_LABEL)
             if not open_issues:
                 _run_completion_gate(
                     repo=repo,
@@ -4483,7 +4558,11 @@ def _run_design_worker(
     # Gate 1: No blocking research issues may remain                     #
     # ------------------------------------------------------------------ #
     if not dry_run:
-        open_research_issues = _list_open_issues_by_label(repo, milestone, RESEARCH_LABEL)
+        # Use _list_all_open_issues_by_label so in-progress research issues (those
+        # with open PRs that haven't merged yet) are included in the blocking check.
+        # _list_open_issues_by_label filters them out, making the gate a no-op when
+        # all research is claimed but nothing has merged yet.
+        open_research_issues = _list_all_open_issues_by_label(repo, milestone, RESEARCH_LABEL)
         blocking, _ = _classify_blocking_issues(
             open_research_issues, repo, milestone, config, checkpoint, store=store
         )

--- a/tests/integration/test_design.py
+++ b/tests/integration/test_design.py
@@ -45,7 +45,7 @@ class TestDesignWorkerGates:
         with (
             patch("brimstone.cli._get_default_branch_for_repo", return_value="mainline"),
             patch(
-                "brimstone.cli._list_open_issues_by_label",
+                "brimstone.cli._list_all_open_issues_by_label",
                 return_value=[make_issue(1, "Blocking research")],
             ),
         ):
@@ -66,7 +66,8 @@ class TestDesignWorkerGates:
 
         with (
             patch("brimstone.cli._get_default_branch_for_repo", return_value="mainline"),
-            patch("brimstone.cli._list_open_issues_by_label", side_effect=[[], [hld]]),
+            patch("brimstone.cli._list_all_open_issues_by_label", return_value=[]),
+            patch("brimstone.cli._list_open_issues_by_label", return_value=[hld]),
             patch("brimstone.cli._doc_exists_on_default_branch", return_value=False),
             patch("brimstone.cli._claim_issue"),
             patch("brimstone.cli._unclaim_issue"),
@@ -105,10 +106,11 @@ class TestDesignWorkerHLDPhase:
         # (LLD recovery checks will not be called since lld_issues is empty)
         with (
             patch("brimstone.cli._get_default_branch_for_repo", return_value="mainline"),
-            # Gate 1 research → []; Phase 1 design → [hld]; Phase 2 LLD → []
+            patch("brimstone.cli._list_all_open_issues_by_label", return_value=[]),
+            # Phase 1 design → [hld]; Phase 2 LLD → []
             patch(
                 "brimstone.cli._list_open_issues_by_label",
-                side_effect=[[], [hld], []],
+                side_effect=[[hld], []],
             ),
             patch(
                 "brimstone.cli._doc_exists_on_default_branch",
@@ -150,7 +152,8 @@ class TestDesignWorkerHLDPhase:
         # doc_exists: HLD already on branch (Phase 1 skip + Gate 2 pass)
         with (
             patch("brimstone.cli._get_default_branch_for_repo", return_value="mainline"),
-            # Call 1: Gate 1 research → []; Gate 2 passes (HLD on branch); Call 2: Phase 2 LLD → []
+            patch("brimstone.cli._list_all_open_issues_by_label", return_value=[]),
+            # Gate 2 passes (HLD on branch); Phase 2 LLD → []
             patch("brimstone.cli._list_open_issues_by_label", return_value=[]),
             patch("brimstone.cli._doc_exists_on_default_branch", return_value=True),
             patch("brimstone.cli._dispatch_design_agent", side_effect=spy_dispatch),
@@ -189,8 +192,9 @@ class TestDesignWorkerLLDPhase:
         # 4. LLD recovery for "runner"→ False (not yet merged)
         with (
             patch("brimstone.cli._get_default_branch_for_repo", return_value="mainline"),
-            # Call 1: Gate 1 research → []; Call 2: Phase 2 LLD listing → llds
-            patch("brimstone.cli._list_open_issues_by_label", side_effect=[[], llds]),
+            patch("brimstone.cli._list_all_open_issues_by_label", return_value=[]),
+            # Phase 2 LLD listing → llds
+            patch("brimstone.cli._list_open_issues_by_label", return_value=llds),
             patch(
                 "brimstone.cli._doc_exists_on_default_branch",
                 side_effect=[True, True, False, False],

--- a/tests/unit/test_cli_design.py
+++ b/tests/unit/test_cli_design.py
@@ -124,7 +124,7 @@ def make_design_issue(number: int, title: str) -> dict:
 
 _DESIGN_PATCHES = {
     "count_research": "brimstone.cli._count_open_issues_by_label",
-    "list_research": "brimstone.cli._list_open_issues_by_label",
+    "list_research": "brimstone.cli._list_all_open_issues_by_label",
     "classify_blocking": "brimstone.cli._classify_blocking_issues",
     "default_branch": "brimstone.cli._get_default_branch_for_repo",
     "repo_root": "brimstone.cli._get_repo_root",

--- a/tests/unit/test_cli_research.py
+++ b/tests/unit/test_cli_research.py
@@ -559,6 +559,7 @@ class TestRunResearchWorkerCompletionGate:
 
         with (
             patch("brimstone.cli._list_open_issues_by_label", return_value=[]),
+            patch("brimstone.cli._list_all_open_issues_by_label", return_value=[]),
             patch("brimstone.cli._run_completion_gate") as mock_gate,
             patch("brimstone.cli.logger.log_conductor_event"),
             patch("brimstone.cli.session.save"),
@@ -583,6 +584,7 @@ class TestRunResearchWorkerCompletionGate:
 
         with (
             patch("brimstone.cli._list_open_issues_by_label", return_value=open_issues),
+            patch("brimstone.cli._list_all_open_issues_by_label", return_value=open_issues),
             patch("brimstone.cli._classify_blocking_issues", return_value=([], open_issues)),
             patch("brimstone.cli._run_completion_gate") as mock_gate,
             patch("brimstone.cli.logger.log_conductor_event"),


### PR DESCRIPTION
## Root cause

Two bugs combined to let brimstone advance to design while research PRs were still open:

**Bug 1 — Design Gate 1 (silent pass)**
`_list_open_issues_by_label` filters out issues that have assignees or the `in-progress` label. Once research agents claim issues and create PRs, the issues are in-progress. So Gate 1 saw 0 open research issues and passed immediately, even though 5 PRs hadn't merged yet.

**Bug 2 — Research `_when_empty` stall exit**
When all research agents complete and their PRs are queued (`merge_ready` bead state), `_when_empty` counts those beads as 'blocking open', returns `False`, stall counter ticks up, and after `STALL_MAX_ITERATIONS` the loop exits WITHOUT merging the queued PRs and WITHOUT calling the completion gate properly.

## Fix

- Add `_list_all_open_issues_by_label` — same query without the assignee/in-progress filter
- Design Gate 1 uses the new helper so in-progress research issues are visible
- Research `_when_empty`: when all blocking beads are `merge_ready`, drain `_process_merge_queue` then re-check before returning `False`
- Fallback (no bead store) `_when_empty` also uses the new helper for consistency

## Tests
- All 560 tests pass
- Updated design integration tests and unit tests to patch the correct function