### PR TITLE
fix: retry squash merge on 'not mergeable' GitHub eventual-consistency race

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -3208,14 +3208,26 @@ def _process_merge_queue(
                 )
                 break
 
-        # Squash-merge
-        merge_result = _gh(
-            ["pr", "merge", str(pr_number), "--squash", "--delete-branch"],
-            repo=repo,
-            check=False,
-        )
+        # Squash-merge — retry a few times to handle GitHub's eventual-consistency
+        # window: after a rebase force-push (or after sibling PRs merged first),
+        # the GraphQL mergeability can briefly return "not mergeable" even when
+        # gh pr view shows mergeStateStatus=CLEAN.
+        _merge_delays = [3, 8, 15]
+        merge_result = None
+        for _delay in [0] + _merge_delays:
+            if _delay:
+                time.sleep(_delay)
+            merge_result = _gh(
+                ["pr", "merge", str(pr_number), "--squash", "--delete-branch"],
+                repo=repo,
+                check=False,
+            )
+            if merge_result.returncode == 0:
+                break
+            if "not mergeable" not in (merge_result.stderr or "").lower():
+                break  # non-retriable error
 
-        if merge_result.returncode == 0:
+        if merge_result is not None and merge_result.returncode == 0:
             now_str = datetime.now(UTC).isoformat()
             pr_bead = store.read_pr_bead(pr_number)
             if pr_bead is not None:
@@ -3249,7 +3261,7 @@ def _process_merge_queue(
                     "pr_number": pr_number,
                     "issue_number": issue_number,
                     "reason": "squash merge failed",
-                    "stderr": merge_result.stderr[:500] if merge_result.stderr else "",
+                    "stderr": (merge_result.stderr or "")[:500] if merge_result is not None else "",
                 },
                 log_dir=config.log_dir.expanduser(),
             )


### PR DESCRIPTION
## Problem

When multiple research PRs are in the merge queue, the first 4 merge
successfully, but subsequent PRs fail with:

```
GraphQL: Pull Request is not mergeable (mergePullRequest)
```

This happens because GitHub's merge-readiness evaluation is eventually
consistent. After sibling PRs merge (advancing `mainline`), or after a
rebase force-push, GitHub briefly marks the PR as "not mergeable" in
GraphQL even though `mergeStateStatus=CLEAN` in the REST API.

The PR then gets silently dropped from the merge queue, leaving the
`WorkBead` stuck in `merge_ready` forever. The research completion gate
then stalls because the bead is `merge_ready` (not `closed`) and issue
is still open on GitHub.

## Fix

Retry the `gh pr merge --squash --delete-branch` call up to 3 times
(3s → 8s → 15s backoff) when the failure message contains "not
mergeable". Non-retriable errors (wrong repo, already merged, etc.)
still fail immediately on the first attempt.

## Root cause evidence

Conductor log showed `pr_merged` (enqueued) at 01:04:27, then
`human_escalate` (squash merge failed, "not mergeable") at 01:04:29
for PR #51 — 2 seconds after the previous PR in the batch merged.
Repeated 5 more times across two subsequent runs.

Manual `gh pr merge 51 --squash --delete-branch` succeeded immediately
once the other PRs had settled.