### PR TITLE
fix: research skip gate guards against bead-less GitHub research issues

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -6484,9 +6484,7 @@ def run(
                         # Guard: plan can file new research issues that have no beads yet.
                         # If beads look complete, confirm no open GitHub issues exist.
                         if _r_done and repo_ref:
-                            _gh_open = _list_all_open_issues_by_label(
-                                repo_ref, ms, RESEARCH_LABEL
-                            )
+                            _gh_open = _list_all_open_issues_by_label(repo_ref, ms, RESEARCH_LABEL)
                             if _gh_open:
                                 _r_done = False
                         if _r_done:

--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -6481,6 +6481,14 @@ def run(
                         _r_done = _r_beads and not any(
                             b.state in ("open", "claimed", "merge_ready") for b in _r_beads
                         )
+                        # Guard: plan can file new research issues that have no beads yet.
+                        # If beads look complete, confirm no open GitHub issues exist.
+                        if _r_done and repo_ref:
+                            _gh_open = _list_all_open_issues_by_label(
+                                repo_ref, ms, RESEARCH_LABEL
+                            )
+                            if _gh_open:
+                                _r_done = False
                         if _r_done:
                             click.echo(
                                 f"[run] {stage} ({ms}): already complete, skipping", err=True


### PR DESCRIPTION
## Problem

When the plan phase creates new research issues for a milestone that
already has all research beads closed (e.g. a P1 issue filed during
v0.2.0 plan after all original research PRs merged), those issues have
no beads. The research skip gate checks only beads:

```python
_r_done = _r_beads and not any(
    b.state in ("open", "claimed", "merge_ready") for b in _r_beads
)
```

With all beads `closed` and no bead for the new issue, `_r_done = True`
and research is skipped. The design Gate 1 then immediately blocks:

```
Error: 1 blocking research issue(s) still open for milestone 'v0.2.0' (#53)
```

Observed on calculator v0.2.0: issue #53 (P1 lexer IDENT research) was
created during the plan phase after the 7 original research PRs all merged.

## Fix

Add a GitHub check after the bead-based gate: if beads look complete but
open `stage/research` issues exist on GitHub for the milestone, do not
skip research. The worker will claim and close them normally.