### PR TITLE
fix: design Gate 1 skips issues with closed beads (GitHub stale-close race)

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -1514,6 +1514,10 @@ def _classify_blocking_issues(
         if store is not None:
             bead = store.read_work_bead(issue_number)
             if bead is not None:
+                # If the bead is already closed/abandoned, the GitHub issue is
+                # stale (eventual-consistency lag after PR merge). Skip it.
+                if bead.state in ("closed", "abandoned"):
+                    continue
                 deferred = bead.deferred
         if deferred:
             non_blocking.append(issue)


### PR DESCRIPTION
## Problem

When the research merge queue drains the last PR and the research worker
declares the stage complete, the design worker's Gate 1 immediately runs
`_list_all_open_issues_by_label` against the GitHub API. Due to GitHub's
eventual-consistency, a PR-closed issue can still appear as open for a
brief window (<1 second after merge).

Result: design Gate 1 blocks with:
```
Error: 1 blocking research issue(s) still open for milestone 'v0.2.0' (#58).
All blocking research must complete before design can begin.
```

Even though PR #64 already merged and issue #58's bead is `closed`.

Observed on calculator v0.2.0: issue #58 merged at 02:46:35Z, then
immediately blocked design Gate 1 at 02:46:36Z.

## Fix

`_classify_blocking_issues` now skips any issue whose `WorkBead` is
already in `closed` or `abandoned` state. The BeadStore is the
authoritative source of truth for issue lifecycle state; the GitHub
issues list is eventually consistent and should not veto bead-confirmed
completions.