### PR TITLE
fix: scope LLD dedup to milestone; close PRs for abandoned issues

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -658,7 +658,7 @@ def _resume_open_prs(
     except json.JSONDecodeError:
         return
 
-    # Fetch all impl issues for the milestone (open + closed) to build a number set
+    # Fetch all impl issues for the milestone (open + closed) to build lookup maps
     issues_result = _gh(
         [
             "issue",
@@ -670,7 +670,7 @@ def _resume_open_prs(
             "--milestone",
             milestone,
             "--json",
-            "number",
+            "number,state",
             "--limit",
             "200",
         ],
@@ -678,11 +678,12 @@ def _resume_open_prs(
         check=False,
     )
     try:
-        milestone_issue_numbers: set[int] = {
-            i["number"] for i in json.loads(issues_result.stdout or "[]")
-        }
+        _issues = json.loads(issues_result.stdout or "[]")
+        milestone_issue_numbers: set[int] = {i["number"] for i in _issues}
+        open_issue_numbers: set[int] = {i["number"] for i in _issues if i["state"] == "OPEN"}
     except (json.JSONDecodeError, KeyError):
         milestone_issue_numbers = set()
+        open_issue_numbers = set()
 
     for pr in open_prs:
         branch: str = pr.get("headRefName") or ""
@@ -698,6 +699,24 @@ def _resume_open_prs(
         if issue_number not in milestone_issue_numbers:
             continue
         if issue_number in already_handled:
+            continue
+        # If the issue was closed (abandoned/manually closed), close the PR too
+        if issue_number not in open_issue_numbers:
+            click.echo(
+                f"{log_prefix} Closing PR #{pr_number}: issue #{issue_number} was closed",
+                err=True,
+            )
+            _gh(
+                [
+                    "pr",
+                    "close",
+                    str(pr_number),
+                    "--comment",
+                    f"Closing: issue #{issue_number} was closed before this PR merged.",
+                ],
+                repo=repo,
+                check=False,
+            )
             continue
         click.echo(
             f"{log_prefix} Resuming untracked open PR #{pr_number} for issue #{issue_number}",
@@ -1049,11 +1068,26 @@ def _file_design_issue_if_missing(
 ) -> None:
     """Create a ``stage/design`` issue with *title* in *repo* if it doesn't already exist.
 
-    Fetches all open+closed issues and checks for an exact title match before
-    creating, making this call idempotent on re-run.
+    Fetches all open+closed issues scoped to *milestone* and checks for an exact
+    title match before creating, making this call idempotent on re-run.
+
+    Scoping to the milestone prevents false-positive dedup matches against
+    identically-titled issues from prior milestones (e.g. "Design: LLD for lexer"
+    from v0.1.0 should not block filing the same title for v0.2.0).
     """
     result = _gh(
-        ["issue", "list", "--state", "all", "--limit", "500", "--json", "title"],
+        [
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--milestone",
+            milestone,
+            "--limit",
+            "500",
+            "--json",
+            "title",
+        ],
         repo=repo,
         check=False,
     )


### PR DESCRIPTION
## Root causes

### Bug 1 — LLD issues silently skipped across milestones

`_file_design_issue_if_missing` checked `gh issue list --state all` with **no `--milestone` filter**.

When the HLD agent tried to file "Design: LLD for lexer" for v0.2.0, the dedup query found the closed v0.1.0 issue with the same title and returned early without creating anything. All subsequent LLD issues also failed to file (exit code 1 on `gh issue create` because the HLD agent's own bash loop hit an error after the skip).

Fix: add `--milestone milestone` to the dedup query so only same-milestone issues are compared.

### Bug 2 — Open PRs for abandoned issues get monitored instead of closed

`_resume_open_prs` fetched issue numbers (open+closed) for the milestone and called `_monitor_pr` for any matching open PR — regardless of whether the issue itself was still open. When issue #100 was abandoned/closed, its PR #107 stayed open indefinitely.

Fix: fetch `number,state` for milestone issues; PRs whose issue is `CLOSED` get `gh pr close` instead of being monitored.

## Impact

- Prevents brimstone from silently skipping LLD issues when a same-named issue exists in a prior milestone
- Prevents orphaned open PRs from accumulating when issues are abandoned mid-pipeline