### PR TITLE
feat(monitor): continuous health monitor, bead pipeline fixes, health check redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,22 @@ Tests live in `tests/`. Default branch: `mainline`.
 
 ### When to create beads
 
-- **Research/impl issues**: seeded in bulk by `_seed_work_beads` at stage startup.
-- **Design LLD issues**: created by `_run_design_worker` Phase 2 self-heal — parse `### Module:` headings from the merged HLD, call `_file_design_issue_if_missing` for each missing module, then `_seed_work_beads` to create the bead. Always check existing beads first, not GitHub issues.
-- **Never** create a bead for an issue that has `state="closed"` or `state="abandoned"` — those are terminal.
+Every tracked work item — research, design, and impl issues, plus milestones and campaigns — has a corresponding bead. GitHub issues/PRs are inputs and outputs; beads are the ledger.
+
+**WorkBeads** (one per issue, all stages):
+
+- **Research issues**: seeded in bulk by `_seed_work_beads(stage="research")` at research-worker startup. `_seed_work_beads` is the single GitHub → bead sync point; all subsequent dispatch reads from beads only.
+- **Design HLD issue**: filed by `_file_design_issue_if_missing` at research completion gate; the bead is created when `_seed_work_beads(stage="design")` runs at design-worker startup. Dedup check must use `store.list_work_beads(stage="design")` — not `gh issue list`.
+- **Design LLD issues**: filed by `_run_design_worker` Phase 2 self-heal — parse `### Module:` headings from the merged HLD, call `_file_design_issue_if_missing` for each missing module, then `_seed_work_beads(stage="design")` to create beads. Always check existing beads first, not GitHub issues.
+- **Impl issues**: seeded in bulk by `_seed_work_beads(stage="impl")` at impl-worker startup (after scope agent has filed the issues on GitHub).
+- **Never** create a bead for an issue that has `state="closed"` or `state="abandoned"` — those are terminal. `_seed_work_beads` skips existing beads; it never overwrites.
+
+**CampaignBead** (one per repo, at `campaign.json`; cross-repo aware):
+
+- Created when `brimstone run` is invoked with multiple milestones (a campaign). Tracks the ordered milestone list, per-milestone status (`pending → planning → researching → designing → scoping → implementing → shipped`), and cross-repo milestone blockers.
+- **Pinned to one repo**, but can declare cross-repo dependencies: `milestone_blocked_by` maps a milestone name → list of `"owner/repo:milestone"` strings that must be `"shipped"` before that milestone can begin. The bead tracks only this repo's milestones; the foreign-repo entries are dependency pointers, not owned state.
+- Milestone progress is read from `store.read_campaign_bead()`. The `status` command uses the campaign bead as primary source; GitHub milestone queries are a fallback when no campaign bead exists.
+- Update the campaign bead via `store.write_campaign_bead()` whenever milestone status changes (e.g. after impl completes for a milestone). Do not use GitHub issue counts as the gate for advancing campaign status — use bead states.
 
 ## Module Isolation
 

--- a/src/brimstone/beads.py
+++ b/src/brimstone/beads.py
@@ -1,16 +1,18 @@
 """Bead files — atomic JSON state for brimstone orchestration.
 
-Replaces checkpoint.json for issue/PR lifecycle tracking. Five bead types:
+Replaces checkpoint.json for issue/PR lifecycle tracking. Six bead types:
   - WorkBead:       issue lifecycle (claimed → pr_open → merge_ready → closed)
   - PRBead:         PR + feedback triage state
   - MergeQueue:     sequential merge ordering (replaces inline gh pr merge calls)
   - CampaignBead:   multi-milestone campaign progress tracking
   - MilestoneBead:  per-milestone lifecycle state (one file per milestone)
+  - AnomalyBead:    monitor-detected aberration lifecycle (open → repaired | wont_fix)
 
 Beads are stored under ~/.brimstone/beads/<owner>/<repo>/:
   work/<issue_number>.json
   prs/pr-<pr_number>.json
   milestones/<milestone-name>.json
+  anomalies/<anomaly_id>.json        ← pinned to the repo where anomaly was detected
   merge-queue.json
   campaign.json
   events/work-<issue_number>.jsonl   ← append-only state-transition log
@@ -171,6 +173,32 @@ class MilestoneBead:
 
 
 @dataclass
+class AnomalyBead:
+    """Monitor-detected aberration — one file per anomaly, pinned to source repo.
+
+    Lifecycle: open → repaired | wont_fix
+    Auto-repair anomalies attempt inline fixes; deferred anomalies file a GH issue
+    in the source repo's ``repairs`` milestone and wait for human resolution.
+    """
+
+    v: int = 1
+    anomaly_id: str = ""  # first 16 hex chars of SHA-256(fingerprint)
+    source_repo: str = ""  # "owner/repo" where anomaly was detected
+    kind: str = ""  # e.g. "label_drift", "dep_cycle"
+    severity: str = ""  # "warning" | "critical"
+    is_blocking: bool = False  # blocks the active milestone's critical path
+    repair_tier: str = "probe"  # "inline" | "bug" | "probe"
+    description: str = ""
+    details: dict = field(default_factory=dict)
+    state: str = "open"  # "open" | "repaired" | "wont_fix"
+    auto_repair_attempts: int = 0
+    gh_issue_number: int | None = None
+    gh_issue_url: str | None = None
+    detected_at: str = ""
+    resolved_at: str | None = None
+
+
+@dataclass
 class BeadEvent:
     """A single state-transition event appended to an events JSONL file."""
 
@@ -256,6 +284,7 @@ class BeadStore:
         (beads_dir / "work").mkdir(parents=True, exist_ok=True)
         (beads_dir / "prs").mkdir(parents=True, exist_ok=True)
         (beads_dir / "milestones").mkdir(parents=True, exist_ok=True)
+        (beads_dir / "anomalies").mkdir(parents=True, exist_ok=True)
         (beads_dir / "events").mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------
@@ -277,6 +306,9 @@ class BeadStore:
     def _milestone_path(self, name: str) -> Path:
         safe_name = name.replace("/", "-")
         return self._beads_dir / "milestones" / f"{safe_name}.json"
+
+    def _anomaly_path(self, anomaly_id: str) -> Path:
+        return self._beads_dir / "anomalies" / f"{anomaly_id}.json"
 
     def _events_path(self, bead_type: str, bead_id: str) -> Path:
         return self._beads_dir / "events" / f"{bead_type}-{bead_id}.jsonl"
@@ -411,6 +443,31 @@ class BeadStore:
         """Atomically write *bead* to disk."""
         path = self._milestone_path(bead.name)
         _atomic_write(path, _milestone_bead_to_dict(bead))
+
+    def read_anomaly_bead(self, anomaly_id: str) -> AnomalyBead | None:
+        """Return the AnomalyBead for *anomaly_id*, or None if absent."""
+        path = self._anomaly_path(anomaly_id)
+        if not path.exists():
+            return None
+        return _load_anomaly_bead(path)
+
+    def write_anomaly_bead(self, bead: AnomalyBead) -> None:
+        """Atomically write *bead* to disk."""
+        path = self._anomaly_path(bead.anomaly_id)
+        _atomic_write(path, _anomaly_bead_to_dict(bead))
+
+    def list_anomaly_beads(self, state: str | None = None) -> list[AnomalyBead]:
+        """Return all AnomalyBeads, optionally filtered by *state*."""
+        anomalies_dir = self._beads_dir / "anomalies"
+        results: list[AnomalyBead] = []
+        for p in sorted(anomalies_dir.glob("*.json")):
+            try:
+                bead = _load_anomaly_bead(p)
+            except BeadCorruptError:
+                continue
+            if state is None or bead.state == state:
+                results.append(bead)
+        return results
 
     # ------------------------------------------------------------------
     # Lists
@@ -762,4 +819,29 @@ def _load_milestone_bead(path: Path) -> MilestoneBead:
 
 
 def _milestone_bead_to_dict(bead: MilestoneBead) -> dict:
+    return asdict(bead)
+
+
+def _load_anomaly_bead(path: Path) -> AnomalyBead:
+    data = _load_json(path)
+    return AnomalyBead(
+        v=data.get("v", 1),
+        anomaly_id=data.get("anomaly_id", ""),
+        source_repo=data.get("source_repo", ""),
+        kind=data.get("kind", ""),
+        severity=data.get("severity", ""),
+        is_blocking=data.get("is_blocking", False),
+        repair_tier=data.get("repair_tier", "deferred"),
+        description=data.get("description", ""),
+        details=data.get("details", {}),
+        state=data.get("state", "open"),
+        auto_repair_attempts=data.get("auto_repair_attempts", 0),
+        gh_issue_number=data.get("gh_issue_number"),
+        gh_issue_url=data.get("gh_issue_url"),
+        detected_at=data.get("detected_at", ""),
+        resolved_at=data.get("resolved_at"),
+    )
+
+
+def _anomaly_bead_to_dict(bead: AnomalyBead) -> dict:
     return asdict(bead)

--- a/src/brimstone/beads.py
+++ b/src/brimstone/beads.py
@@ -1,18 +1,23 @@
 """Bead files — atomic JSON state for brimstone orchestration.
 
-Replaces checkpoint.json for issue/PR lifecycle tracking. Four bead types:
-  - WorkBead:    issue lifecycle (claimed → pr_open → merge_ready → closed)
-  - PRBead:      PR + feedback triage state
-  - MergeQueue:  sequential merge ordering (replaces inline gh pr merge calls)
-  - CampaignBead: multi-milestone campaign progress tracking
+Replaces checkpoint.json for issue/PR lifecycle tracking. Five bead types:
+  - WorkBead:       issue lifecycle (claimed → pr_open → merge_ready → closed)
+  - PRBead:         PR + feedback triage state
+  - MergeQueue:     sequential merge ordering (replaces inline gh pr merge calls)
+  - CampaignBead:   multi-milestone campaign progress tracking
+  - MilestoneBead:  per-milestone lifecycle state (one file per milestone)
 
 Beads are stored under ~/.brimstone/beads/<owner>/<repo>/:
   work/<issue_number>.json
   prs/pr-<pr_number>.json
+  milestones/<milestone-name>.json
   merge-queue.json
   campaign.json
+  events/work-<issue_number>.jsonl   ← append-only state-transition log
+  events/pr-<pr_number>.jsonl
 
 All writes use write-to-.tmp + os.replace (atomic on POSIX).
+Event log appends use line-at-a-time writes (single POSIX write ≤ 4 KiB).
 """
 
 from __future__ import annotations
@@ -21,6 +26,7 @@ import json
 import os
 import subprocess
 from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -75,6 +81,7 @@ class WorkBead:
     branch: str
     pr_id: str | None = None  # "pr-187", links to PRBead file
     retry_count: int = 0
+    restart_count: int = 0  # nuclear-restart count; exhausted after 2 restarts
     blocked_by: list[int] = field(default_factory=list)  # issue numbers that must close first
     deferred: bool = False  # non-blocking for stage-gate; set at claim time from [DEFERRED] tag
     claimed_at: str | None = None  # ISO UTC
@@ -106,6 +113,9 @@ class MergeQueueEntry:
     issue_number: int
     branch: str
     enqueued_at: str
+    priority: int = 0  # higher = merge sooner; default 0
+    attempts: int = 0  # rebase attempt count; incremented on retriable rebase failures
+    merge_attempts: int = 0  # squash-merge attempt count; incremented on conflict-race retries
 
 
 @dataclass
@@ -138,6 +148,86 @@ class CampaignBead:
     updated_at: str = ""
 
 
+@dataclass
+class MilestoneBead:
+    """Per-milestone lifecycle state — one file per milestone.
+
+    Pinned to one repo.  Cross-repo dependencies are expressed as
+    ``"owner/repo:milestone"`` strings in ``blocked_by``.
+
+    Status values (same vocabulary as CampaignBead.statuses):
+        "pending" | "planning" | "researching" | "designing"
+        | "scoping" | "implementing" | "shipped"
+    """
+
+    v: int
+    repo: str
+    name: str  # milestone title, e.g. "v0.2.0"
+    status: str
+    blocked_by: list[str] = field(default_factory=list)  # ["owner/repo:milestone"]
+    created_at: str | None = None
+    updated_at: str | None = None
+    shipped_at: str | None = None
+
+
+@dataclass
+class BeadEvent:
+    """A single state-transition event appended to an events JSONL file."""
+
+    ts: str  # ISO UTC timestamp
+    bead_type: str  # "work" | "pr"
+    bead_id: str  # str(issue_number) or str(pr_number)
+    from_state: str | None
+    to_state: str
+    meta: dict = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Module-level dep-graph helpers
+# ---------------------------------------------------------------------------
+
+
+def detect_dep_cycles(beads: list[WorkBead]) -> list[list[int]]:
+    """DFS cycle detection over the ``blocked_by`` dependency graph.
+
+    Returns a list of cycle paths (each path is a list of issue numbers that
+    form the cycle).  Returns ``[]`` when the graph is acyclic.
+
+    Only active beads (state not in ``{"closed", "abandoned"}``) participate.
+    """
+    active = {b.issue_number for b in beads if b.state not in ("closed", "abandoned")}
+    graph: dict[int, list[int]] = {
+        b.issue_number: [d for d in b.blocked_by if d in active]
+        for b in beads
+        if b.state not in ("closed", "abandoned")
+    }
+    cycles: list[list[int]] = []
+    visited: set[int] = set()
+    rec_stack: set[int] = set()
+    path: list[int] = []
+
+    def _dfs(node: int) -> bool:
+        visited.add(node)
+        rec_stack.add(node)
+        path.append(node)
+        for neighbour in graph.get(node, []):
+            if neighbour not in visited:
+                if _dfs(neighbour):
+                    return True
+            elif neighbour in rec_stack:
+                cycle_start = path.index(neighbour)
+                cycles.append(path[cycle_start:] + [neighbour])
+                return True
+        path.pop()
+        rec_stack.discard(node)
+        return False
+
+    for node in list(graph):
+        if node not in visited:
+            _dfs(node)
+    return cycles
+
+
 # ---------------------------------------------------------------------------
 # BeadStore
 # ---------------------------------------------------------------------------
@@ -148,6 +238,10 @@ class BeadStore:
 
     All writes are atomic: data is written to a .tmp sibling then os.replace()d
     over the target. On POSIX this guarantees no reader sees a partial write.
+
+    State-transition events are appended to per-bead JSONL files under
+    ``events/``.  Each line is a JSON object; writes are single-call appends
+    (atomic for payloads under the OS page size).
 
     Args:
         beads_dir:        Root directory for this repo's bead files.
@@ -161,6 +255,8 @@ class BeadStore:
         # Ensure subdirs exist
         (beads_dir / "work").mkdir(parents=True, exist_ok=True)
         (beads_dir / "prs").mkdir(parents=True, exist_ok=True)
+        (beads_dir / "milestones").mkdir(parents=True, exist_ok=True)
+        (beads_dir / "events").mkdir(parents=True, exist_ok=True)
 
     # ------------------------------------------------------------------
     # Paths
@@ -177,6 +273,95 @@ class BeadStore:
 
     def _campaign_path(self) -> Path:
         return self._beads_dir / "campaign.json"
+
+    def _milestone_path(self, name: str) -> Path:
+        safe_name = name.replace("/", "-")
+        return self._beads_dir / "milestones" / f"{safe_name}.json"
+
+    def _events_path(self, bead_type: str, bead_id: str) -> Path:
+        return self._beads_dir / "events" / f"{bead_type}-{bead_id}.jsonl"
+
+    # ------------------------------------------------------------------
+    # Event log
+    # ------------------------------------------------------------------
+
+    def append_event(
+        self,
+        bead_type: str,
+        bead_id: str,
+        from_state: str | None,
+        to_state: str,
+        meta: dict | None = None,
+    ) -> None:
+        """Append a state-transition event to the bead's JSONL event log.
+
+        Each call appends exactly one line.  Safe for concurrent readers
+        (readers see complete lines; a partial line is never flushed without
+        the preceding newline because we write the whole line in one call).
+        """
+        event = {
+            "ts": datetime.now(UTC).isoformat(),
+            "bead_type": bead_type,
+            "bead_id": bead_id,
+            "from": from_state,
+            "to": to_state,
+            "meta": meta or {},
+        }
+        path = self._events_path(bead_type, bead_id)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(event) + "\n")
+
+    def read_events(self, bead_type: str, bead_id: str) -> list[BeadEvent]:
+        """Return all events for the given bead, oldest first."""
+        path = self._events_path(bead_type, bead_id)
+        if not path.exists():
+            return []
+        events: list[BeadEvent] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                d = json.loads(line)
+                events.append(
+                    BeadEvent(
+                        ts=d.get("ts", ""),
+                        bead_type=d.get("bead_type", bead_type),
+                        bead_id=d.get("bead_id", bead_id),
+                        from_state=d.get("from"),
+                        to_state=d.get("to", ""),
+                        meta=d.get("meta", {}),
+                    )
+                )
+            except (json.JSONDecodeError, KeyError):
+                continue
+        return events
+
+    # ------------------------------------------------------------------
+    # Dep-graph helpers
+    # ------------------------------------------------------------------
+
+    def check_deps_satisfied(self, bead: WorkBead) -> tuple[bool, list[int]]:
+        """Check whether all ``blocked_by`` deps have reached a terminal state.
+
+        Returns ``(satisfied, blocking)`` where *blocking* is the list of
+        issue numbers that still have a non-terminal bead (or no bead at all).
+        When *satisfied* is True, *blocking* is empty.
+        """
+        blocking: list[int] = []
+        for dep_num in bead.blocked_by:
+            dep = self.read_work_bead(dep_num)
+            if dep is None or dep.state not in ("closed", "abandoned"):
+                blocking.append(dep_num)
+        return (len(blocking) == 0, blocking)
+
+    def detect_dep_cycles(self, milestone: str | None = None) -> list[list[int]]:
+        """Run DFS cycle detection over beads for *milestone* (or all beads).
+
+        Delegates to the module-level :func:`detect_dep_cycles` function.
+        """
+        beads = self.list_work_beads(milestone=milestone)
+        return detect_dep_cycles(beads)
 
     # ------------------------------------------------------------------
     # Reads
@@ -215,6 +400,18 @@ class BeadStore:
         path = self._campaign_path()
         _atomic_write(path, _campaign_bead_to_dict(bead))
 
+    def read_milestone_bead(self, name: str) -> MilestoneBead | None:
+        """Return the MilestoneBead for *name*, or None if absent."""
+        path = self._milestone_path(name)
+        if not path.exists():
+            return None
+        return _load_milestone_bead(path)
+
+    def write_milestone_bead(self, bead: MilestoneBead) -> None:
+        """Atomically write *bead* to disk."""
+        path = self._milestone_path(bead.name)
+        _atomic_write(path, _milestone_bead_to_dict(bead))
+
     # ------------------------------------------------------------------
     # Lists
     # ------------------------------------------------------------------
@@ -242,6 +439,55 @@ class BeadStore:
             results.append(bead)
         return results
 
+    def scope_needs_rerun(self, milestone: str) -> bool:
+        """Return True if a design LLD was closed after scope last ran.
+
+        Compares the latest design bead ``closed`` event timestamp against
+        the earliest impl bead creation event timestamp.  If any design bead
+        closed *after* the first impl bead was seeded, scope ran before all
+        LLDs were merged and must re-run to file the missing impl issues.
+
+        Returns False (don't rerun) when:
+        - No impl beads exist yet (scope hasn't run; handled by the caller).
+        - All design close events predate the earliest impl bead creation.
+        - Event log files are absent (old bead pre-dating event log).
+
+        Returns True (rerun needed) when:
+        - The latest design close event is newer than the earliest impl
+          bead creation event (a new LLD merged after scope ran).
+        - Impl beads exist but none have a creation event (conservative:
+          we can't prove scope was complete, so rerun).
+        """
+        design_beads = self.list_work_beads(milestone=milestone, stage="design")
+        impl_beads = self.list_work_beads(milestone=milestone, stage="impl")
+        if not impl_beads:
+            return False  # scope hasn't run; caller decides whether to run it
+
+        latest_design_close: str | None = None
+        for bead in design_beads:
+            for ev in self.read_events("work", str(bead.issue_number)):
+                if ev.to_state == "closed":
+                    if latest_design_close is None or ev.ts > latest_design_close:
+                        latest_design_close = ev.ts
+
+        if latest_design_close is None:
+            return False  # no design bead has ever closed; nothing to compare
+
+        earliest_impl_created: str | None = None
+        for bead in impl_beads:
+            for ev in self.read_events("work", str(bead.issue_number)):
+                if ev.from_state is None and ev.to_state == "open":
+                    if earliest_impl_created is None or ev.ts < earliest_impl_created:
+                        earliest_impl_created = ev.ts
+                    break
+
+        if earliest_impl_created is None:
+            # Impl beads exist but have no creation events (pre-event-log era).
+            # Be conservative: re-run scope to ensure all LLDs are covered.
+            return True
+
+        return latest_design_close > earliest_impl_created
+
     def list_pr_beads(self, state: str | None = None) -> list[PRBead]:
         """Return all PRBeads, optionally filtered by *state*."""
         prs_dir = self._beads_dir / "prs"
@@ -255,19 +501,60 @@ class BeadStore:
                 results.append(bead)
         return results
 
+    def list_milestone_beads(self, status: str | None = None) -> list[MilestoneBead]:
+        """Return all MilestoneBeads, optionally filtered by *status*."""
+        ms_dir = self._beads_dir / "milestones"
+        results: list[MilestoneBead] = []
+        for p in sorted(ms_dir.glob("*.json")):
+            try:
+                bead = _load_milestone_bead(p)
+            except BeadCorruptError:
+                continue
+            if status is None or bead.status == status:
+                results.append(bead)
+        return results
+
     # ------------------------------------------------------------------
-    # Writes (atomic)
+    # Writes (atomic) + event emission
     # ------------------------------------------------------------------
 
     def write_work_bead(self, bead: WorkBead) -> None:
-        """Atomically write *bead* to disk."""
+        """Atomically write *bead* to disk, appending a state-transition event."""
         path = self._work_path(bead.issue_number)
+        old_state: str | None = None
+        if path.exists():
+            try:
+                old = _load_work_bead(path)
+                old_state = old.state
+            except BeadCorruptError:
+                pass
         _atomic_write(path, _work_bead_to_dict(bead))
+        if bead.state != old_state:
+            self.append_event(
+                bead_type="work",
+                bead_id=str(bead.issue_number),
+                from_state=old_state,
+                to_state=bead.state,
+            )
 
     def write_pr_bead(self, bead: PRBead) -> None:
-        """Atomically write *bead* to disk."""
+        """Atomically write *bead* to disk, appending a state-transition event."""
         path = self._pr_path(bead.pr_number)
+        old_state: str | None = None
+        if path.exists():
+            try:
+                old = _load_pr_bead(path)
+                old_state = old.state
+            except BeadCorruptError:
+                pass
         _atomic_write(path, _pr_bead_to_dict(bead))
+        if bead.state != old_state:
+            self.append_event(
+                bead_type="pr",
+                bead_id=str(bead.pr_number),
+                from_state=old_state,
+                to_state=bead.state,
+            )
 
     def write_merge_queue(self, queue: MergeQueue) -> None:
         """Atomically write the merge queue to disk."""
@@ -419,6 +706,8 @@ def _load_merge_queue(path: Path) -> MergeQueue:
             issue_number=e.get("issue_number", 0),
             branch=e.get("branch", ""),
             enqueued_at=e.get("enqueued_at", ""),
+            priority=e.get("priority", 0),
+            attempts=e.get("attempts", 0),
         )
         for e in data.get("queue", [])
     ]
@@ -455,4 +744,22 @@ def _load_campaign_bead(path: Path) -> CampaignBead:
 
 
 def _campaign_bead_to_dict(bead: CampaignBead) -> dict:
+    return asdict(bead)
+
+
+def _load_milestone_bead(path: Path) -> MilestoneBead:
+    data = _load_json(path)
+    return MilestoneBead(
+        v=data.get("v", BEAD_SCHEMA_VERSION),
+        repo=data.get("repo", ""),
+        name=data.get("name", ""),
+        status=data.get("status", "pending"),
+        blocked_by=data.get("blocked_by", []),
+        created_at=data.get("created_at"),
+        updated_at=data.get("updated_at"),
+        shipped_at=data.get("shipped_at"),
+    )
+
+
+def _milestone_bead_to_dict(bead: MilestoneBead) -> dict:
     return asdict(bead)

--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -9,6 +9,7 @@ Subcommands:
   brimstone adopt   — adopt an existing repo (stub)
   brimstone health  — preflight health checks
   brimstone cost    — cost ledger summary
+  brimstone monitor — watch bead/repo state for aberrations and file bugs
 """
 
 from __future__ import annotations
@@ -29,7 +30,7 @@ from typing import Any
 
 import click
 
-from brimstone import health, logger, runner, session
+from brimstone import health, logger, monitor, runner, session
 from brimstone.beads import (
     BEAD_SCHEMA_VERSION,
     BeadStore,
@@ -37,6 +38,7 @@ from brimstone.beads import (
     MergeQueueEntry,
     PRBead,
     WorkBead,
+    detect_dep_cycles,
     make_bead_store,
 )
 from brimstone.config import (
@@ -717,6 +719,11 @@ def _resume_open_prs(
                 repo=repo,
                 check=False,
             )
+            if store is not None:
+                _closed_bead = store.read_work_bead(issue_number)
+                if _closed_bead is not None and _closed_bead.state not in ("closed", "abandoned"):
+                    _closed_bead.state = "abandoned"
+                    store.write_work_bead(_closed_bead)
             continue
         click.echo(
             f"{log_prefix} Resuming untracked open PR #{pr_number} for issue #{issue_number}",
@@ -823,6 +830,12 @@ def _resume_stale_issues(
             handled.add(stale_number)
         elif _pr_merged_for_issue(repo, stale_number):
             _gh(["issue", "close", str(stale_number)], repo=repo, check=False)
+            if store is not None:
+                _stale_bead = store.read_work_bead(stale_number)
+                if _stale_bead is not None and _stale_bead.state not in ("closed", "abandoned"):
+                    _stale_bead.state = "closed"
+                    _stale_bead.closed_at = datetime.now(UTC).isoformat()
+                    store.write_work_bead(_stale_bead)
             click.echo(
                 f"{log_prefix} Closed #{stale_number} — merged PR found, issue was not auto-closed",
                 err=True,
@@ -1065,39 +1078,44 @@ def _file_design_issue_if_missing(
     milestone: str,
     title: str,
     body: str,
+    store: BeadStore | None = None,
 ) -> None:
     """Create a ``stage/design`` issue with *title* in *repo* if it doesn't already exist.
 
-    Fetches all open+closed issues scoped to *milestone* and checks for an exact
-    title match before creating, making this call idempotent on re-run.
-
-    Scoping to the milestone prevents false-positive dedup matches against
-    identically-titled issues from prior milestones (e.g. "Design: LLD for lexer"
-    from v0.1.0 should not block filing the same title for v0.2.0).
+    When *store* is provided, checks existing design beads first (invariant 3:
+    dedup against beads, not GitHub issues). Falls back to a GitHub issue-list
+    query only when no store is available.
     """
-    result = _gh(
-        [
-            "issue",
-            "list",
-            "--state",
-            "all",
-            "--milestone",
-            milestone,
-            "--limit",
-            "500",
-            "--json",
-            "title",
-        ],
-        repo=repo,
-        check=False,
-    )
-    if result.returncode == 0:
-        try:
-            existing = {i["title"] for i in json.loads(result.stdout)}
-            if title in existing:
-                return
-        except (json.JSONDecodeError, KeyError):
-            pass
+    if store is not None:
+        existing_titles = {
+            b.title for b in store.list_work_beads(milestone=milestone, stage="design")
+        }
+        if title in existing_titles:
+            return
+    else:
+        result = _gh(
+            [
+                "issue",
+                "list",
+                "--state",
+                "all",
+                "--milestone",
+                milestone,
+                "--limit",
+                "500",
+                "--json",
+                "title",
+            ],
+            repo=repo,
+            check=False,
+        )
+        if result.returncode == 0:
+            try:
+                existing = {i["title"] for i in json.loads(result.stdout)}
+                if title in existing:
+                    return
+            except (json.JSONDecodeError, KeyError):
+                pass
 
     _gh(
         [
@@ -1217,7 +1235,8 @@ def _filter_unblocked(
             bead = store.read_work_bead(issue_number)
             if bead is not None:
                 blocked = any(
-                    (dep_bead := store.read_work_bead(dep)) is None or dep_bead.state != "closed"
+                    (dep_bead := store.read_work_bead(dep)) is None
+                    or dep_bead.state not in ("closed", "abandoned")
                     for dep in bead.blocked_by
                 )
                 if not blocked:
@@ -1360,6 +1379,39 @@ def _startup_dep_checks(open_issues: list[dict[str, Any]], repo: str) -> None:
         raise SystemExit(1)
 
 
+def _startup_dep_checks_from_beads(beads: list[WorkBead], repo: str) -> None:
+    """Bead-native dependency validation and cycle detection at worker startup.
+
+    Unknown deps (referenced in blocked_by but without a bead or GitHub issue)
+    emit a warning and are treated as unblocked.  Cycles abort with exit code 1.
+    Cycle detection is delegated to :func:`beads.detect_dep_cycles`.
+    """
+    active_numbers = {b.issue_number for b in beads if b.state not in ("closed", "abandoned")}
+    all_referenced: set[int] = set()
+    for bead in beads:
+        if bead.state not in ("closed", "abandoned"):
+            all_referenced.update(bead.blocked_by)
+    for dep in sorted(all_referenced - active_numbers):
+        result = _gh(["issue", "view", str(dep), "--json", "number"], repo=repo, check=False)
+        if result.returncode != 0:
+            click.echo(
+                f"[dep-check] Warning: issue #{dep} referenced as a dependency does not "
+                f"exist on GitHub. The depending issue will be treated as unblocked.",
+                err=True,
+            )
+    cycles = detect_dep_cycles(beads)
+    if cycles:
+        for cycle in cycles:
+            nums = " → ".join(f"#{n}" for n in cycle)
+            click.echo(f"[dep-check] Error: dependency cycle detected: {nums}", err=True)
+        click.echo(
+            "[dep-check] Resolve the cycle(s) above before dispatching. "
+            "Break a cycle by adding [DEFERRED] to one issue's body or closing it.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+
 def _claim_issue(
     repo: str,
     issue_number: int,
@@ -1434,7 +1486,7 @@ def _unclaim_issue(repo: str, issue_number: int, store: BeadStore | None = None)
     """
     if store is not None:
         bead = store.read_work_bead(issue_number)
-        if bead is not None and bead.state not in ("abandoned", "closed"):
+        if bead is not None and bead.state not in ("abandoned", "closed", "merge_ready"):
             bead.state = "open"
             store.write_work_bead(bead)
     info = _gh(
@@ -1712,6 +1764,75 @@ def _dispatch_research_agent(
     return issue, branch_name, worktree_path, result
 
 
+def _prune_stale_dependencies(
+    repo: str,
+    milestone: str,
+    store: BeadStore,
+    config: Config,
+    checkpoint: Checkpoint,
+) -> bool:
+    """Remove 'Depends on: #N' refs that point to closed issues.
+
+    Scans open issues in the milestone for dependency references.  For each
+    reference pointing to a closed issue, removes the text from the issue body
+    and removes the dependency from the corresponding WorkBead.
+
+    Returns:
+        True if at least one stale dependency was pruned; False otherwise.
+    """
+    issues_result = _gh(
+        ["issue", "list", "--milestone", milestone, "--state", "open", "--json", "number,body"],
+        repo=repo,
+        check=False,
+    )
+    try:
+        issues = json.loads(issues_result.stdout or "[]")
+    except (json.JSONDecodeError, AttributeError):
+        return False
+
+    pruned = False
+    for issue in issues:
+        body = issue.get("body") or ""
+        issue_number = issue["number"]
+        refs = re.findall(r"Depends on: #(\d+)", body)
+        for ref_str in refs:
+            ref = int(ref_str)
+            state_result = _gh(
+                ["issue", "view", str(ref), "--json", "state", "--jq", ".state"],
+                repo=repo,
+                check=False,
+            )
+            state = (state_result.stdout or "").strip().upper()
+            if state != "CLOSED":
+                continue
+            # Remove the stale dependency from the issue body
+            new_body = re.sub(rf"\nDepends on: #{ref}", "", body)
+            _gh(
+                ["issue", "edit", str(issue_number), "--body", new_body],
+                repo=repo,
+                check=False,
+            )
+            body = new_body  # update for subsequent iterations
+            # Remove from WorkBead
+            _dep_bead = store.read_work_bead(issue_number)
+            if _dep_bead is not None and ref in _dep_bead.blocked_by:
+                _dep_bead.blocked_by.remove(ref)
+                store.write_work_bead(_dep_bead)
+            logger.log_conductor_event(
+                run_id=checkpoint.run_id,
+                phase="stall",
+                event_type="human_escalate",
+                payload={
+                    "issue_number": issue_number,
+                    "pruned_dep": ref,
+                    "reason": f"stale dependency #{ref} closed; removed from issue #{issue_number}",
+                },
+                log_dir=config.log_dir.expanduser(),
+            )
+            pruned = True
+    return pruned
+
+
 def _run_persistent_pool(
     *,
     pool_size: int,
@@ -1761,8 +1882,9 @@ def _run_persistent_pool(
         stall_reason:  Human-readable reason logged on deadlock escalation.
     """
     checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
-    # In-memory fallback retry tracker used when store is None.
+    # In-memory fallback retry/restart trackers used when store is None.
     _retry_counts: dict[int, int] = {}
+    _restart_counts: dict[int, int] = {}
     stall_count: int = 0
     _watchdog_tick: int = 0
     active: dict = {}
@@ -1775,6 +1897,20 @@ def _run_persistent_pool(
                 break
             stall_count += 1
             if stall_count >= STALL_MAX_ITERATIONS:
+                # Before escalating, try pruning stale Depends-on references
+                if store is not None and milestone:
+                    _pruned = _prune_stale_dependencies(
+                        repo=repo,
+                        milestone=milestone,
+                        store=store,
+                        config=config,
+                        checkpoint=checkpoint,
+                    )
+                    if _pruned:
+                        stall_count = 0
+                        fill_fn(active)
+                        if active:
+                            continue  # work unblocked — restart pool loop
                 logger.log_conductor_event(
                     run_id=checkpoint.run_id,
                     phase="stall",
@@ -1894,26 +2030,59 @@ def _run_persistent_pool(
                 _delete_remote_branch(repo, _branch)
                 if current_retries >= MAX_RETRIES:
                     reason = result.subtype or "unknown_error"
-                    _exhaust_issue(repo, issue_number, reason, store)
-                    click.echo(
-                        f"[{stage}] #{issue_number} exhausted {MAX_RETRIES} retries "
-                        f"({reason}) — closed with 'bug' label. Reopen to retry.",
-                        err=True,
+                    _restart_count = (
+                        _bead.restart_count
+                        if _bead is not None
+                        else _restart_counts.get(issue_number, 0)
                     )
-                    logger.log_conductor_event(
-                        run_id=checkpoint.run_id,
-                        phase="dispatch",
-                        event_type="human_escalate",
-                        payload={
-                            "issue_number": issue_number,
-                            "reason": reason,
-                            "error_code": result.error_code,
-                            "retry_count": current_retries,
-                            "stderr": result.stderr[:500] if result.stderr else "",
-                            "action_required": "manual investigation",
-                        },
-                        log_dir=config.log_dir.expanduser(),
-                    )
+                    if _restart_count < 2:
+                        # Nuclear restart: reset retry state and re-queue the issue
+                        if _bead is not None:
+                            _bead.restart_count = _restart_count + 1
+                            _bead.retry_count = 0
+                            _bead.state = "open"
+                            store.write_work_bead(_bead)  # type: ignore[union-attr]
+                        else:
+                            _restart_counts[issue_number] = _restart_count + 1
+                            _retry_counts[issue_number] = 0
+                        _unclaim_issue(repo=repo, issue_number=issue_number, store=store)
+                        logger.log_conductor_event(
+                            run_id=checkpoint.run_id,
+                            phase="dispatch",
+                            event_type="agent_nuclear_restart",
+                            payload={
+                                "issue_number": issue_number,
+                                "reason": reason,
+                                "error_code": result.error_code,
+                                "retry_count": current_retries,
+                                "restart_count": _restart_count + 1,
+                                "stderr": result.stderr[:500] if result.stderr else "",
+                            },
+                            log_dir=config.log_dir.expanduser(),
+                        )
+                    else:
+                        # Exhausted restart budget — close with bug label
+                        _exhaust_issue(repo, issue_number, reason, store)
+                        click.echo(
+                            f"[{stage}] #{issue_number} exhausted {MAX_RETRIES} retries "
+                            f"({reason}) — closed with 'bug' label. Reopen to retry.",
+                            err=True,
+                        )
+                        logger.log_conductor_event(
+                            run_id=checkpoint.run_id,
+                            phase="dispatch",
+                            event_type="human_escalate",
+                            payload={
+                                "issue_number": issue_number,
+                                "reason": reason,
+                                "error_code": result.error_code,
+                                "retry_count": current_retries,
+                                "restart_count": _restart_count,
+                                "stderr": result.stderr[:500] if result.stderr else "",
+                                "action_required": "manual investigation",
+                            },
+                            log_dir=config.log_dir.expanduser(),
+                        )
                 else:
                     _unclaim_issue(repo=repo, issue_number=issue_number, store=store)
                 _remove_worktree(_worktree_path, repo_root)
@@ -1996,7 +2165,13 @@ def _run_research_worker(
             repo_root=repo_root,
             store=store,
         )
-        _startup_dep_checks(_list_open_issues_by_label(repo, milestone, RESEARCH_LABEL), repo)
+        if store is not None:
+            _seed_work_beads(repo, milestone, RESEARCH_LABEL, "research", store)
+            _startup_dep_checks_from_beads(
+                store.list_work_beads(milestone=milestone, stage="research"), repo
+            )
+        else:
+            _startup_dep_checks(_list_open_issues_by_label(repo, milestone, RESEARCH_LABEL), repo)
 
     research_limits: dict[str, int] = {"pro": 2, "max": 3, "max20x": 5}
     pool_size = config.max_concurrency or research_limits.get(config.subscription_tier, 3)
@@ -2046,7 +2221,7 @@ def _run_research_worker(
                     and not b.deferred
                     and all(
                         (dep_bead := store.read_work_bead(dep)) is not None
-                        and dep_bead.state == "closed"
+                        and dep_bead.state in ("closed", "abandoned")
                         for dep in b.blocked_by
                     )
                 ]
@@ -2208,6 +2383,7 @@ def _run_research_worker(
                     store=store,
                     worktree_path=worktree_path,
                     default_branch=default_branch,
+                    repo_root=repo_root,
                 )
             else:
                 click.echo(
@@ -2239,6 +2415,7 @@ def _run_research_worker(
                         config=config,
                         checkpoint=checkpoint,
                         dry_run=False,
+                        store=store,
                     )
                     return True
                 blocking = [b for b in open_beads if not b.deferred]
@@ -2253,6 +2430,7 @@ def _run_research_worker(
                         config=config,
                         checkpoint=checkpoint,
                         dry_run=False,
+                        store=store,
                     )
                     return True
                 # All blocking beads are in merge_ready state — their PRs are
@@ -2278,6 +2456,7 @@ def _run_research_worker(
                             config=config,
                             checkpoint=checkpoint,
                             dry_run=False,
+                            store=store,
                         )
                         return True
                     blocking = [b for b in open_beads if not b.deferred]
@@ -2292,6 +2471,7 @@ def _run_research_worker(
                             config=config,
                             checkpoint=checkpoint,
                             dry_run=False,
+                            store=store,
                         )
                         return True
                 return False
@@ -2394,6 +2574,7 @@ def _run_completion_gate(
     config: Config,
     checkpoint: Checkpoint,
     dry_run: bool = False,
+    store: BeadStore | None = None,
 ) -> None:
     """Declare research milestone complete, migrate non-blocking issues, file the HLD issue.
 
@@ -2407,6 +2588,7 @@ def _run_completion_gate(
         config:      Current Config instance.
         checkpoint:  Current Checkpoint instance.
         dry_run:     If True, print actions without modifying GitHub.
+        store:       BeadStore for bead-first dedup when filing HLD issue.
     """
     checkpoint_path = config.checkpoint_dir.expanduser() / "current.json"
 
@@ -2451,6 +2633,7 @@ def _run_completion_gate(
             repo=repo,
             milestone=milestone,
             title=hld_title,
+            store=store,
             body=(
                 "## Deliverable\n"
                 f"`docs/design/{milestone}/HLD.md`\n\n"
@@ -2958,6 +3141,7 @@ def _monitor_pr(
     default_branch: str = "main",
     max_polls: int = _CI_MAX_POLLS,
     poll_interval: int = _CI_POLL_INTERVAL,
+    repo_root: str = "",
 ) -> bool:
     """Monitor a PR's CI status and squash-merge it when CI passes.
 
@@ -2991,6 +3175,7 @@ def _monitor_pr(
     rebase_attempts = 0
     ci_fail_count = 0
     consecutive_no_checks = 0  # grace counter: empty CI after force-push vs no CI configured
+    last_head_sha: str = ""  # track HEAD to reset ci_fail_count when agent pushes a fix
 
     # Write initial PRBead
     pr_bead = PRBead(
@@ -3004,169 +3189,245 @@ def _monitor_pr(
     if store is not None:
         store.write_pr_bead(pr_bead)
 
-    for poll_idx in range(max_polls):
-        time.sleep(poll_interval)
+    timeout_count = 0
+    while True:
+        for poll_idx in range(max_polls):
+            time.sleep(poll_interval)
 
-        # Detect merge conflicts at the start of every poll — this fires even
-        # while CI is still pending so we don't wait 30 min before rebasing.
-        if _is_conflict_failure(repo, pr_number):
-            if not worktree_path:
-                # No worktree available (e.g. research PRs) — can't rebase
-                logger.log_conductor_event(
-                    run_id=checkpoint.run_id,
-                    phase="ci_check",
-                    event_type="human_escalate",
-                    payload={
-                        "pr_number": pr_number,
-                        "issue_number": issue_number,
-                        "reason": "conflict detected but no worktree for rebase",
-                    },
-                    log_dir=config.log_dir.expanduser(),
+            # Detect merge conflicts at the start of every poll — this fires even
+            # while CI is still pending so we don't wait 30 min before rebasing.
+            if _is_conflict_failure(repo, pr_number):
+                if not worktree_path:
+                    # No worktree available — try to create a temp one if repo_root provided
+                    _tmp_wt = (
+                        _checkout_existing_branch_worktree(branch, repo_root) if repo_root else None
+                    )
+                    if _tmp_wt:
+                        worktree_path = _tmp_wt
+                    else:
+                        logger.log_conductor_event(
+                            run_id=checkpoint.run_id,
+                            phase="ci_check",
+                            event_type="human_escalate",
+                            payload={
+                                "pr_number": pr_number,
+                                "issue_number": issue_number,
+                                "reason": "conflict detected but no worktree for rebase",
+                            },
+                            log_dir=config.log_dir.expanduser(),
+                        )
+                        pr_bead.state = "conflict"
+                        if store is not None:
+                            store.write_pr_bead(pr_bead)
+                        return False
+
+                if rebase_attempts >= _REBASE_RETRY_LIMIT:
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="ci_check",
+                        event_type="human_escalate",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "reason": "rebase limit exceeded",
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+                    pr_bead.state = "conflict"
+                    if store is not None:
+                        store.write_pr_bead(pr_bead)
+                    return False
+
+                rebase_ok = _rebase_branch(
+                    branch, repo, worktree_path, default_branch, config=config
                 )
-                pr_bead.state = "conflict"
-                if store is not None:
-                    store.write_pr_bead(pr_bead)
-                return False
-
-            if rebase_attempts >= _REBASE_RETRY_LIMIT:
-                logger.log_conductor_event(
-                    run_id=checkpoint.run_id,
-                    phase="ci_check",
-                    event_type="human_escalate",
-                    payload={
-                        "pr_number": pr_number,
-                        "issue_number": issue_number,
-                        "reason": "rebase limit exceeded",
-                    },
-                    log_dir=config.log_dir.expanduser(),
-                )
-                pr_bead.state = "conflict"
-                if store is not None:
-                    store.write_pr_bead(pr_bead)
-                return False
-
-            rebase_ok = _rebase_branch(branch, repo, worktree_path, default_branch, config=config)
-            rebase_attempts += 1
-            if not rebase_ok:
-                logger.log_conductor_event(
-                    run_id=checkpoint.run_id,
-                    phase="ci_check",
-                    event_type="human_escalate",
-                    payload={
-                        "pr_number": pr_number,
-                        "issue_number": issue_number,
-                        "reason": "rebase failed — conflicts outside agent scope",
-                    },
-                    log_dir=config.log_dir.expanduser(),
-                )
-                pr_bead.state = "conflict"
-                if store is not None:
-                    store.write_pr_bead(pr_bead)
-                return False
-            # Rebase succeeded — continue polling so CI can re-run
-            continue
-
-        ci_status = _get_pr_checks_status(repo, pr_number)
-
-        # Handle the "no checks yet" case: distinguish a brief post-push race
-        # (CI not triggered yet) from "repo has no CI configured".
-        # After _CI_NO_CHECKS_GRACE consecutive no_checks polls, treat as pass.
-        if ci_status == "no_checks":
-            consecutive_no_checks += 1
-            if consecutive_no_checks < _CI_NO_CHECKS_GRACE:
-                continue  # wait for CI to appear
-            ci_status = "pass"  # grace exhausted — no CI configured
-        else:
-            consecutive_no_checks = 0  # reset when real checks appear
-
-        logger.log_conductor_event(
-            run_id=checkpoint.run_id,
-            phase="ci_check",
-            event_type="ci_checked",
-            payload={
-                "pr_number": pr_number,
-                "issue_number": issue_number,
-                "status": ci_status,
-                "poll_index": poll_idx,
-            },
-            log_dir=config.log_dir.expanduser(),
-        )
-
-        if ci_status == "pass":
-            # Check reviews
-            review_status = _get_review_status(repo, pr_number)
-
-            if review_status == "changes_requested":
-                # Record that review feedback is pending — do NOT dispatch a fix agent.
-                # Agents handle their own review feedback via updated skill files (PR 5).
-                pr_bead.state = "reviewing"
-                if store is not None:
-                    store.write_pr_bead(pr_bead)
-                # Continue polling — agent may push a fix commit
+                rebase_attempts += 1
+                if not rebase_ok:
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="ci_check",
+                        event_type="human_escalate",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "reason": "rebase failed — conflicts outside agent scope",
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+                    pr_bead.state = "conflict"
+                    if store is not None:
+                        store.write_pr_bead(pr_bead)
+                    return False
+                # Rebase succeeded — continue polling so CI can re-run
                 continue
 
-            # Enqueue to MergeQueue — _process_merge_queue() does the actual merge
-            _now_str = datetime.now(UTC).isoformat()
-            if store is not None:
-                _queue = store.read_merge_queue()
-                _queue.queue.append(
-                    MergeQueueEntry(
-                        pr_number=pr_number,
-                        issue_number=issue_number,
-                        branch=branch,
-                        enqueued_at=_now_str,
-                    )
-                )
-                _queue.updated_at = _now_str
-                store.write_merge_queue(_queue)
-                pr_bead.state = "merge_ready"
-                store.write_pr_bead(pr_bead)
-                _work_bead = store.read_work_bead(issue_number)
-                if _work_bead is not None:
-                    _work_bead.state = "merge_ready"
-                    store.write_work_bead(_work_bead)
+            # Track HEAD SHA — if agent pushes a fix commit, reset ci_fail_count so
+            # a fresh CI run isn't counted as a continuation of the previous failure.
+            _sha_result = _gh(
+                ["pr", "view", str(pr_number), "--json", "headRefOid", "--jq", ".headRefOid"],
+                repo=repo,
+                check=False,
+            )
+            _current_sha = (_sha_result.stdout or "").strip()
+            if _current_sha and _current_sha != last_head_sha:
+                if last_head_sha:  # not first poll — new commit landed
+                    ci_fail_count = 0
+                last_head_sha = _current_sha
+
+            ci_status = _get_pr_checks_status(repo, pr_number)
+
+            # Handle the "no checks yet" case: distinguish a brief post-push race
+            # (CI not triggered yet) from "repo has no CI configured".
+            # After _CI_NO_CHECKS_GRACE consecutive no_checks polls, treat as pass.
+            if ci_status == "no_checks":
+                consecutive_no_checks += 1
+                if consecutive_no_checks < _CI_NO_CHECKS_GRACE:
+                    continue  # wait for CI to appear
+                ci_status = "pass"  # grace exhausted — no CI configured
+            else:
+                consecutive_no_checks = 0  # reset when real checks appear
+
             logger.log_conductor_event(
                 run_id=checkpoint.run_id,
-                phase="merge",
-                event_type="pr_merged",
+                phase="ci_check",
+                event_type="ci_checked",
                 payload={
                     "pr_number": pr_number,
                     "issue_number": issue_number,
-                    "branch": branch,
-                    "queued": True,
+                    "status": ci_status,
+                    "poll_index": poll_idx,
                 },
                 log_dir=config.log_dir.expanduser(),
             )
-            return True
 
-        elif ci_status == "fail":
-            ci_fail_count += 1
-            if ci_fail_count <= 1:
-                # First failure: may be transient — poll once more
-                pr_bead.ci_state = "failing"
+            if ci_status == "pass":
+                # Check reviews
+                review_status = _get_review_status(repo, pr_number)
+
+                if review_status == "changes_requested":
+                    # Record that review feedback is pending — do NOT dispatch a fix agent.
+                    # Agents handle their own review feedback via updated skill files (PR 5).
+                    pr_bead.state = "reviewing"
+                    if store is not None:
+                        store.write_pr_bead(pr_bead)
+                    # Continue polling — agent may push a fix commit
+                    continue
+
+                # Log inline comment presence for observability before enqueue
+                _inline_result = _gh(
+                    ["api", f"repos/{repo}/pulls/{pr_number}/comments", "--jq", "length"],
+                    repo=repo,
+                    check=False,
+                )
+                try:
+                    _inline_count = int((_inline_result.stdout or "0").strip())
+                except ValueError:
+                    _inline_count = 0
+                if _inline_count > 0:
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="ci_check",
+                        event_type="inline_comments_present",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "count": _inline_count,
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+
+                # Enqueue to MergeQueue — _process_merge_queue() does the actual merge
+                _now_str = datetime.now(UTC).isoformat()
                 if store is not None:
+                    _queue = store.read_merge_queue()
+                    _work_bead = store.read_work_bead(issue_number)
+                    _priority = 0
+                    if _work_bead is not None:
+                        _p = _work_bead.priority or ""
+                        _priority = {"P0": 40, "P1": 30, "P2": 20, "P3": 10, "P4": 5}.get(_p, 0)
+                    _queue.queue.append(
+                        MergeQueueEntry(
+                            pr_number=pr_number,
+                            issue_number=issue_number,
+                            branch=branch,
+                            enqueued_at=_now_str,
+                            priority=_priority,
+                        )
+                    )
+                    _queue.queue.sort(key=lambda e: e.priority, reverse=True)
+                    _queue.updated_at = _now_str
+                    store.write_merge_queue(_queue)
+                    pr_bead.state = "merge_ready"
                     store.write_pr_bead(pr_bead)
-            else:
-                # Persistent failure — escalate; agents should fix CI via updated skills (PR 5)
-                pr_bead.state = "ci_failing"
-                pr_bead.ci_state = "failing"
-                if store is not None:
-                    store.write_pr_bead(pr_bead)
+                    if _work_bead is not None:
+                        _work_bead.state = "merge_ready"
+                        store.write_work_bead(_work_bead)
                 logger.log_conductor_event(
                     run_id=checkpoint.run_id,
-                    phase="ci_check",
-                    event_type="human_escalate",
+                    phase="merge",
+                    event_type="pr_merged",
                     payload={
                         "pr_number": pr_number,
                         "issue_number": issue_number,
-                        "reason": "ci failed (persistent); agent should fix via skill",
-                        "ci_fail_count": ci_fail_count,
+                        "branch": branch,
+                        "queued": True,
                     },
                     log_dir=config.log_dir.expanduser(),
                 )
-                return False
+                return True
 
-        # ci_status == "pending": continue polling
+            elif ci_status == "fail":
+                ci_fail_count += 1
+                if ci_fail_count < 3:
+                    # Transient failure or agent still fixing — poll again
+                    pr_bead.ci_state = "failing"
+                    if store is not None:
+                        store.write_pr_bead(pr_bead)
+                else:
+                    # Persistent failure — escalate; agents should fix CI via updated skills (PR 5)
+                    pr_bead.state = "ci_failing"
+                    pr_bead.ci_state = "failing"
+                    if store is not None:
+                        store.write_pr_bead(pr_bead)
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="ci_check",
+                        event_type="human_escalate",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "reason": "ci failed (persistent); agent should fix via skill",
+                            "ci_fail_count": ci_fail_count,
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+                    return False
+
+            # ci_status == "pending": continue polling
+
+        # Inner poll loop timed out — try one empty-commit re-trigger if worktree available
+        if worktree_path and os.path.isdir(worktree_path) and timeout_count < 1:
+            timeout_count += 1
+            subprocess.run(
+                [
+                    "git",
+                    "commit",
+                    "--allow-empty",
+                    "-m",
+                    "ci: re-trigger [skip-duplicate-detection]",
+                ],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "push"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+            )
+            continue  # restart poll loop with fresh CI run
+        break  # second timeout or no worktree → fall through
 
     # Timeout
     pr_bead.state = "abandoned"
@@ -3223,14 +3484,19 @@ def _process_merge_queue(
     if orphaned:
         now_str = datetime.now(UTC).isoformat()
         for pr_bead in orphaned:
+            _wb = store.read_work_bead(pr_bead.issue_number)
+            _p = (_wb.priority or "") if _wb else ""
+            _priority = {"P0": 40, "P1": 30, "P2": 20, "P3": 10, "P4": 5}.get(_p, 0)
             queue.queue.append(
                 MergeQueueEntry(
                     pr_number=pr_bead.pr_number,
                     issue_number=pr_bead.issue_number,
                     branch=pr_bead.branch,
                     enqueued_at=now_str,
+                    priority=_priority,
                 )
             )
+        queue.queue.sort(key=lambda e: e.priority, reverse=True)
         store.write_merge_queue(queue)
 
     if not queue.queue:
@@ -3252,7 +3518,27 @@ def _process_merge_queue(
             finally:
                 _remove_worktree(wt_path, repo_root)
             if not rebase_ok:
-                # Rebase failed — push to tail, stop processing
+                entry.attempts += 1
+                if entry.attempts >= _REBASE_RETRY_LIMIT:
+                    # Cap exceeded — write conflict state and discard entry
+                    _pr_bead_rb = store.read_pr_bead(pr_number)
+                    if _pr_bead_rb is not None:
+                        _pr_bead_rb.state = "conflict"
+                        store.write_pr_bead(_pr_bead_rb)
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="merge",
+                        event_type="human_escalate",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "reason": "merge queue rebase limit exceeded",
+                            "attempts": entry.attempts,
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+                    continue  # discard entry, process rest of queue
+                # Push to tail, stop processing current pass
                 remaining.append(entry)
                 logger.log_conductor_event(
                     run_id=checkpoint.run_id,
@@ -3262,6 +3548,7 @@ def _process_merge_queue(
                         "pr_number": pr_number,
                         "issue_number": issue_number,
                         "reason": "rebase failed in merge queue; pushed to tail",
+                        "attempts": entry.attempts,
                     },
                     log_dir=config.log_dir.expanduser(),
                 )
@@ -3312,20 +3599,80 @@ def _process_merge_queue(
                 log_dir=config.log_dir.expanduser(),
             )
         else:
-            logger.log_conductor_event(
-                run_id=checkpoint.run_id,
-                phase="merge",
-                event_type="human_escalate",
-                payload={
-                    "pr_number": pr_number,
-                    "issue_number": issue_number,
-                    "reason": "squash merge failed",
-                    "stderr": (merge_result.stderr or "")[:500] if merge_result is not None else "",
-                },
-                log_dir=config.log_dir.expanduser(),
-            )
-            # Remove from queue — won't be retried automatically
-            # (Watchdog or human intervention needed)
+            _merge_stderr = (merge_result.stderr or "").lower() if merge_result is not None else ""
+            _governance_keywords = ("required status check", "review required", "protected branch")
+            if any(kw in _merge_stderr for kw in _governance_keywords):
+                # Governance block — write conflict state, discard entry
+                _pr_bead_gv = store.read_pr_bead(pr_number)
+                if _pr_bead_gv is not None:
+                    _pr_bead_gv.state = "conflict"
+                    store.write_pr_bead(_pr_bead_gv)
+                logger.log_conductor_event(
+                    run_id=checkpoint.run_id,
+                    phase="merge",
+                    event_type="human_escalate",
+                    payload={
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "reason": "squash merge failed: governance block",
+                        "stderr": _merge_stderr[:500],
+                    },
+                    log_dir=config.log_dir.expanduser(),
+                )
+                # Entry discarded — fall through to next iteration
+            elif _is_conflict_failure(repo, pr_number):
+                # Re-conflict race after rebase — retry up to merge_attempts cap
+                entry.merge_attempts += 1
+                if entry.merge_attempts < _REBASE_RETRY_LIMIT:
+                    remaining.insert(0, entry)  # retry at head of queue
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="merge",
+                        event_type="human_escalate",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "reason": "squash merge conflict race; re-queued at head",
+                            "merge_attempts": entry.merge_attempts,
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+                    break  # restart drain from top
+                else:
+                    _pr_bead_cr = store.read_pr_bead(pr_number)
+                    if _pr_bead_cr is not None:
+                        _pr_bead_cr.state = "conflict"
+                        store.write_pr_bead(_pr_bead_cr)
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="merge",
+                        event_type="human_escalate",
+                        payload={
+                            "pr_number": pr_number,
+                            "issue_number": issue_number,
+                            "reason": "squash merge conflict race limit exceeded",
+                            "merge_attempts": entry.merge_attempts,
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+            else:
+                # Transient failure — write conflict state, discard entry
+                _pr_bead_tr = store.read_pr_bead(pr_number)
+                if _pr_bead_tr is not None:
+                    _pr_bead_tr.state = "conflict"
+                    store.write_pr_bead(_pr_bead_tr)
+                logger.log_conductor_event(
+                    run_id=checkpoint.run_id,
+                    phase="merge",
+                    event_type="human_escalate",
+                    payload={
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "reason": "squash merge failed: transient error",
+                        "stderr": _merge_stderr[:500],
+                    },
+                    log_dir=config.log_dir.expanduser(),
+                )
 
     # Write updated queue (with processed entries removed, remaining intact)
     queue.queue = remaining
@@ -3435,7 +3782,7 @@ def _dispatch_recovery_agent(
     env = build_subprocess_env(config)
     runner.run(
         prompt=prompt,
-        allowed_tools=["Bash"],
+        allowed_tools=runner.TOOLS_IMPL_AGENT,
         env=env,
         max_turns=60,
         timeout_seconds=config.agent_timeout_minutes * 60,
@@ -4225,7 +4572,13 @@ def _run_impl_worker(
             already_handled=handled,
             store=store,
         )
-        _startup_dep_checks(_list_open_issues_by_label(repo, milestone, IMPL_LABEL), repo)
+        if store is not None:
+            _seed_work_beads(repo, milestone, IMPL_LABEL, "impl", store)
+            _startup_dep_checks_from_beads(
+                store.list_work_beads(milestone=milestone, stage="impl"), repo
+            )
+        else:
+            _startup_dep_checks(_list_open_issues_by_label(repo, milestone, IMPL_LABEL), repo)
         if store is not None:
             _ensure_impl_scaffold(
                 repo=repo, milestone=milestone, store=store, default_branch=default_branch
@@ -4242,7 +4595,7 @@ def _run_impl_worker(
                 and not b.deferred
                 and all(
                     (dep_bead := store.read_work_bead(dep)) is not None
-                    and dep_bead.state == "closed"
+                    and dep_bead.state in ("closed", "abandoned")
                     for dep in b.blocked_by
                 )
             ]
@@ -4296,7 +4649,7 @@ def _run_impl_worker(
                     and not b.deferred
                     and all(
                         (dep_bead := store.read_work_bead(dep)) is not None
-                        and dep_bead.state == "closed"
+                        and dep_bead.state in ("closed", "abandoned")
                         for dep in b.blocked_by
                     )
                 ]
@@ -4448,20 +4801,63 @@ def _run_impl_worker(
             issue_number = issue["number"]
             pr_number = _find_pr_for_branch(repo, branch)
             if pr_number is None:
-                logger.log_conductor_event(
-                    run_id=checkpoint.run_id,
-                    phase="dispatch",
-                    event_type="human_escalate",
-                    payload={
-                        "issue_number": issue_number,
-                        "reason": "agent completed but no PR found",
-                        "branch": branch,
-                    },
-                    log_dir=config.log_dir.expanduser(),
+                # Branch was pushed but PR not created — check if there are commits ahead
+                # and try a minimal recovery agent to create the PR automatically.
+                _compare = _gh(
+                    [
+                        "api",
+                        f"repos/{repo}/compare/{default_branch}...{branch}",
+                        "--jq",
+                        ".ahead_by",
+                    ],
+                    repo=repo,
+                    check=False,
                 )
-                _unclaim_issue(repo=repo, issue_number=issue_number, store=store)
-                _remove_worktree(worktree_path, repo_root)
-                return
+                _ahead_by = 0
+                try:
+                    _ahead_by = int((_compare.stdout or "0").strip())
+                except ValueError:
+                    pass
+                if _ahead_by > 0:
+                    # Branch has commits — dispatch a recovery agent to create the PR
+                    _issue_title = issue.get("title", f"Issue #{issue_number}")
+                    _recovery_prompt = (
+                        f"The agent for issue #{issue_number} completed but did not create a PR. "
+                        f"The branch `{branch}` has {_ahead_by} commit(s) ahead of "
+                        f"`{default_branch}`. Your only task: create the PR.\n\n"
+                        f"Run: gh pr create --repo {repo} --head {branch} "
+                        f'--title "{_issue_title}" '
+                        f'--body "Closes #{issue_number}" --base {default_branch}\n\n'
+                        f"Then STOP."
+                    )
+                    _env = build_subprocess_env(config)
+                    runner.run(
+                        prompt=_recovery_prompt,
+                        allowed_tools=["Bash"],
+                        env=_env,
+                        max_turns=10,
+                        timeout_seconds=120,
+                        model=config.model,
+                        prefix=f"[pr-recovery #{issue_number}] ",
+                    )
+                    # Retry PR lookup after recovery agent
+                    pr_number = _find_pr_for_branch(repo, branch)
+                if pr_number is None:
+                    logger.log_conductor_event(
+                        run_id=checkpoint.run_id,
+                        phase="dispatch",
+                        event_type="human_escalate",
+                        payload={
+                            "issue_number": issue_number,
+                            "reason": "agent completed but no PR found",
+                            "branch": branch,
+                            "ahead_by": _ahead_by,
+                        },
+                        log_dir=config.log_dir.expanduser(),
+                    )
+                    _unclaim_issue(repo=repo, issue_number=issue_number, store=store)
+                    _remove_worktree(worktree_path, repo_root)
+                    return
             session.save(checkpoint, checkpoint_path)
             logger.log_conductor_event(
                 run_id=checkpoint.run_id,
@@ -4513,11 +4909,11 @@ def _run_impl_worker(
                 logger.log_conductor_event(
                     run_id=checkpoint.run_id,
                     phase="merge",
-                    event_type="human_escalate",
+                    event_type="ci_monitoring_complete_no_merge",
                     payload={
                         "issue_number": issue_number,
                         "pr_number": pr_number,
-                        "reason": "CI monitoring did not result in merge",
+                        "reason": "CI monitoring did not result in merge; watchdog will handle",
                     },
                     log_dir=config.log_dir.expanduser(),
                 )
@@ -4716,11 +5112,22 @@ def _run_design_worker(
     elif _doc_exists_on_default_branch(repo, hld_doc_path, default_branch):
         click.echo("HLD already merged — skipping Phase 1")
     else:
-        # Find the HLD issue (may have been filed by completion gate or on a previous run)
-        design_issues = _list_open_issues_by_label(repo, milestone, DESIGN_LABEL)
-        hld_issue = next((i for i in design_issues if i["title"] == hld_issue_title), None)
-        if hld_issue is None:
-            # Missing — create it (idempotent) and re-fetch
+        # Seed design beads first, then find HLD via beads (source of truth)
+        if store is not None:
+            _seed_work_beads(repo, milestone, DESIGN_LABEL, "design", store)
+
+        hld_bead = None
+        hld_issue: dict[str, Any] | None = None
+        if store is not None:
+            hld_bead = next(
+                (
+                    b
+                    for b in store.list_work_beads(milestone=milestone, stage="design")
+                    if b.title == hld_issue_title and b.state not in ("closed", "abandoned")
+                ),
+                None,
+            )
+        if hld_bead is None:
             _file_design_issue_if_missing(
                 repo,
                 milestone,
@@ -4735,9 +5142,36 @@ def _run_design_worker(
                     "issue with label `stage/design` and this milestone. "
                     "Check for duplicates before filing."
                 ),
+                store=store,
             )
-            design_issues = _list_open_issues_by_label(repo, milestone, DESIGN_LABEL)
-            hld_issue = next((i for i in design_issues if i["title"] == hld_issue_title), None)
+            if store is not None:
+                _seed_work_beads(repo, milestone, DESIGN_LABEL, "design", store)
+                hld_bead = next(
+                    (
+                        b
+                        for b in store.list_work_beads(milestone=milestone, stage="design")
+                        if b.title == hld_issue_title and b.state not in ("closed", "abandoned")
+                    ),
+                    None,
+                )
+            if hld_bead is None:
+                design_issues = _list_open_issues_by_label(repo, milestone, DESIGN_LABEL)
+                hld_issue = next((i for i in design_issues if i["title"] == hld_issue_title), None)
+
+        if hld_bead is not None:
+            _view = _gh(
+                ["issue", "view", str(hld_bead.issue_number), "--json", "number,title,body"],
+                repo=repo,
+                check=False,
+            )
+            try:
+                hld_issue = json.loads(_view.stdout)
+            except (json.JSONDecodeError, AttributeError):
+                hld_issue = {
+                    "number": hld_bead.issue_number,
+                    "title": hld_bead.title,
+                    "body": "",
+                }
 
         if hld_issue is None:
             click.echo("Error: Could not find or create HLD design issue.", err=True)
@@ -4891,12 +5325,39 @@ def _run_design_worker(
                         f"public API/interfaces, error handling, and test strategy "
                         f"for this module."
                     ),
+                    store=store,
                 )
             # Seed beads from GitHub so newly created issues get beads
             _seed_work_beads(repo, milestone, DESIGN_LABEL, "design", store)
 
-    all_design_issues = _list_open_issues_by_label(repo, milestone, DESIGN_LABEL)
-    lld_issues = [i for i in all_design_issues if i["title"] != hld_issue_title]
+    # Build LLD issue list — beads are source of truth when store is available.
+    # Fetch full issue bodies at dispatch time so agents have design instructions.
+    if store is not None:
+        _lld_beads = [
+            b
+            for b in store.list_work_beads(state="open", milestone=milestone, stage="design")
+            if b.title != hld_issue_title
+        ]
+        lld_issues: list[dict[str, Any]] = []
+        for _b in _lld_beads:
+            _bview = _gh(
+                [
+                    "issue",
+                    "view",
+                    str(_b.issue_number),
+                    "--json",
+                    "number,title,body,labels,assignees,milestone",
+                ],
+                repo=repo,
+                check=False,
+            )
+            try:
+                lld_issues.append(json.loads(_bview.stdout))
+            except (json.JSONDecodeError, AttributeError):
+                lld_issues.append({"number": _b.issue_number, "title": _b.title, "body": ""})
+    else:
+        all_design_issues = _list_open_issues_by_label(repo, milestone, DESIGN_LABEL)
+        lld_issues = [i for i in all_design_issues if i["title"] != hld_issue_title]
 
     if not lld_issues:
         click.echo(
@@ -5691,10 +6152,10 @@ def _run_plan(
     if not dry_run:
         try:
             if _milestone_exists(repo, version):
-                existing = _count_open_issues_by_label(repo, version, RESEARCH_LABEL)
+                existing = _count_all_issues_by_label(repo, version, RESEARCH_LABEL)
                 if existing > 0:
                     click.echo(
-                        f"[plan] milestone {version!r} exists with {existing} open research"
+                        f"[plan] milestone {version!r} exists with {existing} research"
                         " issue(s) — plan stage skipped (already seeded)."
                     )
                     return
@@ -6192,8 +6653,12 @@ def _check_gate_before_stage(
     repo: str,
     milestone: str,
     default_branch: str,
+    store: BeadStore | None = None,
 ) -> None:
     """Abort with a clear error if a prerequisite stage has not been completed.
+
+    Bead-first: when *store* is provided, gates check bead state directly.
+    Falls back to GitHub issue counts when no store is available.
 
     Gates are only applied when the prerequisite stage is NOT also being run in
     the same invocation (e.g. ``--all`` skips both gates because research and
@@ -6205,17 +6670,32 @@ def _check_gate_before_stage(
         repo:              GitHub repository in ``owner/repo`` format.
         milestone:         Active milestone name.
         default_branch:    Default branch of the remote repo.
+        store:             BeadStore for bead-first checks, or None.
 
     Raises:
         click.ClickException: If the prerequisite is not satisfied.
     """
     if stage == "design" and "research" not in stages_being_run:
-        open_count = _count_open_issues_by_label(repo, milestone, RESEARCH_LABEL)
-        if open_count > 0:
-            raise click.ClickException(
-                f"{open_count} open research issue(s) remain for milestone '{milestone}'. "
-                "Run `brimstone run --research` first, or use `--all` to run all stages."
-            )
+        if store is not None:
+            research_beads = store.list_work_beads(milestone=milestone, stage="research")
+            blocking = [
+                b
+                for b in research_beads
+                if b.state not in ("closed", "abandoned") and not b.deferred
+            ]
+            if blocking:
+                raise click.ClickException(
+                    f"{len(blocking)} open research bead(s) remain for"
+                    f" milestone '{milestone}'. "
+                    "Run `brimstone run --research` first, or use `--all`."
+                )
+        else:
+            open_count = _count_open_issues_by_label(repo, milestone, RESEARCH_LABEL)
+            if open_count > 0:
+                raise click.ClickException(
+                    f"{open_count} open research issue(s) remain for milestone '{milestone}'. "
+                    "Run `brimstone run --research` first, or use `--all` to run all stages."
+                )
 
     if stage == "scope" and "design" not in stages_being_run:
         hld_path = f"docs/design/{milestone}/HLD.md"
@@ -6226,11 +6706,19 @@ def _check_gate_before_stage(
             )
 
     if stage == "impl" and "scope" not in stages_being_run:
-        if _count_open_issues_by_label(repo, milestone, IMPL_LABEL) == 0:
-            raise click.ClickException(
-                f"No open impl issues found for milestone '{milestone}'. "
-                "Run `brimstone run --scope` first to generate them from the design docs."
-            )
+        if store is not None:
+            impl_beads = store.list_work_beads(milestone=milestone, stage="impl")
+            if not impl_beads:
+                raise click.ClickException(
+                    f"No impl beads found for milestone '{milestone}'. "
+                    "Run `brimstone run --scope` first to generate them from the design docs."
+                )
+        else:
+            if _count_open_issues_by_label(repo, milestone, IMPL_LABEL) == 0:
+                raise click.ClickException(
+                    f"No open impl issues found for milestone '{milestone}'. "
+                    "Run `brimstone run --scope` first to generate them from the design docs."
+                )
 
 
 @brimstone.command("run")
@@ -6311,6 +6799,13 @@ def _check_gate_before_stage(
 @click.option("--model", default=None, help="Override Claude model")
 @click.option("--max-budget", type=float, default=None, help="USD budget cap")
 @click.option("--dry-run", is_flag=True, help="Print what each stage would do without executing")
+@click.option(
+    "--monitor",
+    "monitor_enabled",
+    is_flag=True,
+    default=False,
+    help="Run the bead/repo health monitor as a background thread alongside the pipeline.",
+)
 def run(
     specs: tuple[str, ...],
     repo: str | None,
@@ -6326,6 +6821,7 @@ def run(
     model: str | None,
     max_budget: float | None,
     dry_run: bool,
+    monitor_enabled: bool,
 ) -> None:
     """Run one or more pipeline stages for a milestone.
 
@@ -6489,6 +6985,27 @@ def run(
         _ensure_labels(repo_ref)
 
     # -----------------------------------------------------------------------
+    # Monitor thread — start before the pipeline loop when --monitor is set
+    # -----------------------------------------------------------------------
+    if monitor_enabled and not dry_run and repo_ref:
+        import threading
+
+        _monitor_store = make_bead_store(config, repo_ref)
+
+        def _monitor_thread() -> None:
+            monitor.run_monitor(
+                _monitor_store,
+                repo_ref,
+                once=False,
+                interval=monitor.MONITOR_INTERVAL_SECONDS,
+                dry_run=False,
+            )
+
+        _mt = threading.Thread(target=_monitor_thread, daemon=True, name="brimstone-monitor")
+        _mt.start()
+        click.echo("[monitor] background health monitor started", err=True)
+
+    # -----------------------------------------------------------------------
     # Campaign bead — track multi-milestone progress
     # -----------------------------------------------------------------------
     is_campaign = len(effective_milestones) > 1
@@ -6530,6 +7047,15 @@ def run(
     }
 
     for i, ms in enumerate(effective_milestones):
+        # Fast-path: skip milestones that were already fully shipped in a prior session.
+        if (
+            is_campaign
+            and campaign_store is not None
+            and campaign_bead.statuses.get(ms) == "shipped"
+        ):
+            click.echo(f"[campaign] {ms} already shipped — skipping.", err=True)
+            continue
+
         for stage in stages:
             click.echo(f"\n── Stage: {stage} ({ms}) ──", err=True)
 
@@ -6587,11 +7113,13 @@ def run(
                             b.state in ("open", "claimed", "merge_ready") for b in _r_beads
                         )
                         # Guard: plan can file new research issues that have no beads yet.
-                        # If beads look complete, confirm no open GitHub issues exist.
-                        if _r_done and repo_ref:
-                            _gh_open = _list_all_open_issues_by_label(repo_ref, ms, RESEARCH_LABEL)
-                            if _gh_open:
-                                _r_done = False
+                        # Re-seed to pick up plan-filed issues, then re-check beads.
+                        if _r_done and repo_ref and _skip_store:
+                            _seed_work_beads(repo_ref, ms, RESEARCH_LABEL, "research", _skip_store)
+                            _r_beads = _skip_store.list_work_beads(milestone=ms, stage="research")
+                            _r_done = bool(_r_beads) and not any(
+                                b.state in ("open", "claimed", "merge_ready") for b in _r_beads
+                            )
                         if _r_done:
                             click.echo(
                                 f"[run] {stage} ({ms}): already complete, skipping", err=True
@@ -6623,7 +7151,7 @@ def run(
                             if _skip_store
                             else []
                         )
-                        if _i_beads:
+                        if _i_beads and not (_skip_store and _skip_store.scope_needs_rerun(ms)):
                             click.echo(
                                 f"[run] {stage} ({ms}): impl issues already exist, skipping",
                                 err=True,
@@ -6632,7 +7160,9 @@ def run(
 
                 # Gate check — only when prerequisite is not also in this run
                 if not dry_run:
-                    _check_gate_before_stage(stage, stages, repo_ref, ms, default_branch)
+                    _check_gate_before_stage(
+                        stage, stages, repo_ref, ms, default_branch, store=_skip_store
+                    )
 
                 if dry_run:
                     click.echo(f"[dry-run] would run {stage} for milestone={ms!r}", err=True)
@@ -6688,7 +7218,13 @@ def run(
                             err=True,
                         )
                         while True:
-                            open_count = _count_open_issues_by_label(repo_ref, ms, IMPL_LABEL)
+                            if _store is not None:
+                                _impl_beads = _store.list_work_beads(milestone=ms, stage="impl")
+                                open_count = sum(
+                                    1 for b in _impl_beads if b.state not in ("closed", "abandoned")
+                                )
+                            else:
+                                open_count = _count_open_issues_by_label(repo_ref, ms, IMPL_LABEL)
                             if open_count == 0:
                                 break
                             click.echo(
@@ -6898,10 +7434,53 @@ def status_cmd(repo: str | None) -> None:
         if raw_status == "shipped":
             click.echo(f"{connector} {ms}  [{status_upper}]")
         elif raw_status == "implementing":
-            open_count = _count_open_issues_by_label(repo_ref, ms, IMPL_LABEL)
-            total_count = _count_all_issues_by_label(repo_ref, ms, IMPL_LABEL)
+            _all_impl = store.list_work_beads(milestone=ms, stage="impl") if store else []
+            if _all_impl:
+                open_count = sum(1 for b in _all_impl if b.state not in ("closed", "abandoned"))
+                total_count = len(_all_impl)
+            else:
+                open_count = _count_open_issues_by_label(repo_ref, ms, IMPL_LABEL)
+                total_count = _count_all_issues_by_label(repo_ref, ms, IMPL_LABEL)
             click.echo(
                 f"{connector} {ms}  [{status_upper}  {open_count}/{total_count} issues open]"
             )
         else:
             click.echo(f"{connector} {ms}  [{status_upper}]")
+
+
+@brimstone.command("monitor")
+@click.option(
+    "--repo",
+    default=None,
+    help="Repository in owner/repo format. Inferred from git remote if omitted.",
+)
+@click.option(
+    "--once",
+    is_flag=True,
+    default=False,
+    help="Run one detection pass and exit instead of looping.",
+)
+@click.option(
+    "--interval",
+    default=monitor.MONITOR_INTERVAL_SECONDS,
+    show_default=True,
+    help="Seconds between detection passes (ignored when --once is set).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print anomalies to stdout without filing GitHub issues.",
+)
+def monitor_cmd(repo: str | None, once: bool, interval: int, dry_run: bool) -> None:
+    """Watch bead and repo state for aberrations and file bug issues."""
+    repo_ref = _resolve_repo(repo)
+    if not repo_ref:
+        raise click.UsageError(
+            "Could not determine repository. Pass --repo <owner/repo> or run from a git repo."
+        )
+
+    config = load_config(github_repo=repo_ref, target_repo=repo_ref)
+    store = make_bead_store(config, repo_ref)
+
+    monitor.run_monitor(store, repo_ref, once=once, interval=interval, dry_run=dry_run)

--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -6806,6 +6806,13 @@ def _check_gate_before_stage(
     default=False,
     help="Run the bead/repo health monitor as a background thread alongside the pipeline.",
 )
+@click.option(
+    "--bugs-repo",
+    "bugs_repo",
+    default=None,
+    help="Repository where monitor anomaly issues are filed (should be the brimstone repo). "
+    "Only used when --monitor is set. Defaults to --repo when omitted.",
+)
 def run(
     specs: tuple[str, ...],
     repo: str | None,
@@ -6822,6 +6829,7 @@ def run(
     max_budget: float | None,
     dry_run: bool,
     monitor_enabled: bool,
+    bugs_repo: str | None,
 ) -> None:
     """Run one or more pipeline stages for a milestone.
 
@@ -6996,6 +7004,7 @@ def run(
             monitor.run_monitor(
                 _monitor_store,
                 repo_ref,
+                bugs_repo=bugs_repo,
                 once=False,
                 interval=monitor.MONITOR_INTERVAL_SECONDS,
                 dry_run=False,
@@ -7452,7 +7461,15 @@ def status_cmd(repo: str | None) -> None:
 @click.option(
     "--repo",
     default=None,
-    help="Repository in owner/repo format. Inferred from git remote if omitted.",
+    help="Repository being orchestrated (watched for label/bead drift). "
+    "Inferred from git remote if omitted.",
+)
+@click.option(
+    "--bugs-repo",
+    "bugs_repo",
+    default=None,
+    help="Repository where anomaly bug issues are filed. Defaults to --repo when omitted, "
+    "but should normally be the brimstone repo itself.",
 )
 @click.option(
     "--once",
@@ -7472,8 +7489,10 @@ def status_cmd(repo: str | None) -> None:
     default=False,
     help="Print anomalies to stdout without filing GitHub issues.",
 )
-def monitor_cmd(repo: str | None, once: bool, interval: int, dry_run: bool) -> None:
-    """Watch bead and repo state for aberrations and file bug issues."""
+def monitor_cmd(
+    repo: str | None, bugs_repo: str | None, once: bool, interval: int, dry_run: bool
+) -> None:
+    """Watch bead and repo state for aberrations and file bug issues against bugs-repo."""
     repo_ref = _resolve_repo(repo)
     if not repo_ref:
         raise click.UsageError(
@@ -7483,4 +7502,6 @@ def monitor_cmd(repo: str | None, once: bool, interval: int, dry_run: bool) -> N
     config = load_config(github_repo=repo_ref, target_repo=repo_ref)
     store = make_bead_store(config, repo_ref)
 
-    monitor.run_monitor(store, repo_ref, once=once, interval=interval, dry_run=dry_run)
+    monitor.run_monitor(
+        store, repo_ref, bugs_repo=bugs_repo, once=once, interval=interval, dry_run=dry_run
+    )

--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -1821,7 +1821,7 @@ def _prune_stale_dependencies(
             logger.log_conductor_event(
                 run_id=checkpoint.run_id,
                 phase="stall",
-                event_type="human_escalate",
+                event_type="dependency_pruned",
                 payload={
                     "issue_number": issue_number,
                     "pruned_dep": ref,
@@ -3189,6 +3189,14 @@ def _monitor_pr(
     if store is not None:
         store.write_pr_bead(pr_bead)
 
+    # Track any temp worktree created by the D1 conflict fallback so it is
+    # cleaned up on every exit path (return True, return False, or timeout).
+    _d1_tmp_wt: str = ""
+
+    def _cleanup_d1() -> None:
+        if _d1_tmp_wt and repo_root:
+            _remove_worktree(_d1_tmp_wt, repo_root)
+
     timeout_count = 0
     while True:
         for poll_idx in range(max_polls):
@@ -3204,6 +3212,7 @@ def _monitor_pr(
                     )
                     if _tmp_wt:
                         worktree_path = _tmp_wt
+                        _d1_tmp_wt = _tmp_wt  # mark for cleanup on all exit paths
                     else:
                         logger.log_conductor_event(
                             run_id=checkpoint.run_id,
@@ -3236,6 +3245,7 @@ def _monitor_pr(
                     pr_bead.state = "conflict"
                     if store is not None:
                         store.write_pr_bead(pr_bead)
+                    _cleanup_d1()
                     return False
 
                 rebase_ok = _rebase_branch(
@@ -3257,6 +3267,7 @@ def _monitor_pr(
                     pr_bead.state = "conflict"
                     if store is not None:
                         store.write_pr_bead(pr_bead)
+                    _cleanup_d1()
                     return False
                 # Rebase succeeded — continue polling so CI can re-run
                 continue
@@ -3362,6 +3373,10 @@ def _monitor_pr(
                     if _work_bead is not None:
                         _work_bead.state = "merge_ready"
                         store.write_work_bead(_work_bead)
+                        # Strip in-progress label now that the issue is queued for merge.
+                        # _unclaim_issue's merge_ready guard ensures only the label is
+                        # removed — the bead state is not reset to open.
+                        _unclaim_issue(repo=repo, issue_number=issue_number, store=store)
                 logger.log_conductor_event(
                     run_id=checkpoint.run_id,
                     phase="merge",
@@ -3374,6 +3389,7 @@ def _monitor_pr(
                     },
                     log_dir=config.log_dir.expanduser(),
                 )
+                _cleanup_d1()
                 return True
 
             elif ci_status == "fail":
@@ -3401,6 +3417,7 @@ def _monitor_pr(
                         },
                         log_dir=config.log_dir.expanduser(),
                     )
+                    _cleanup_d1()
                     return False
 
             # ci_status == "pending": continue polling
@@ -3426,6 +3443,11 @@ def _monitor_pr(
                 capture_output=True,
                 text=True,
             )
+            # Reset per-CI-run counters so the new run starts clean
+            rebase_attempts = 0
+            ci_fail_count = 0
+            consecutive_no_checks = 0
+            last_head_sha = ""
             continue  # restart poll loop with fresh CI run
         break  # second timeout or no worktree → fall through
 
@@ -3444,6 +3466,7 @@ def _monitor_pr(
         },
         log_dir=config.log_dir.expanduser(),
     )
+    _cleanup_d1()
     return False
 
 

--- a/src/brimstone/health.py
+++ b/src/brimstone/health.py
@@ -19,6 +19,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
+from brimstone.beads import BeadStore, make_bead_store
 from brimstone.config import Config
 from brimstone.session import Checkpoint, is_backing_off
 
@@ -466,10 +467,76 @@ def _check_worktrees() -> CheckResult:
 
 
 def _check_orphaned_issues(config: Config) -> CheckResult:
-    """Check 6: No stale in-progress issues."""
-    max_orphaned: int = getattr(config, "max_orphaned_issues", 5)
+    """Check 6: No stale in-progress issues (claimed beads with no open PR bead).
 
-    # Get in-progress issues
+    Uses the bead store when available (bead-first: ``state=claimed`` + no PR bead).
+    Falls back to GitHub ``in-progress`` label cross-referenced with open PRs when
+    no bead store is configured.
+    """
+    max_orphaned: int = getattr(config, "max_orphaned_issues", 5)
+    github_repo: str | None = getattr(config, "github_repo", None)
+
+    # ------------------------------------------------------------------
+    # Bead-based check (preferred)
+    # ------------------------------------------------------------------
+    if github_repo:
+        try:
+            store: BeadStore = make_bead_store(config, github_repo)
+            claimed_beads = store.list_work_beads(state="claimed")
+            if not claimed_beads:
+                return CheckResult(
+                    name="No stale in-progress issues",
+                    status="pass",
+                    message="No claimed beads found.",
+                )
+            # Issues with a PR bead in a non-terminal state have active PRs
+            issues_with_open_prs: set[int] = {
+                pb.issue_number
+                for pb in store.list_pr_beads()
+                if pb.state not in ("merged", "abandoned")
+            }
+            orphaned_beads = [
+                b for b in claimed_beads if b.issue_number not in issues_with_open_prs
+            ]
+            count = len(orphaned_beads)
+            total_claimed = len(claimed_beads)
+
+            if count == 0:
+                return CheckResult(
+                    name="No stale in-progress issues",
+                    status="pass",
+                    message=f"{total_claimed} claimed bead(s) all have open PR beads.",
+                )
+
+            issue_list = ", ".join(f"#{b.issue_number} '{b.title}'" for b in orphaned_beads)
+            if count > max_orphaned:
+                return CheckResult(
+                    name="No stale in-progress issues",
+                    status="fail",
+                    message=(
+                        f"Too many orphaned claimed beads: {count} with no open PR bead "
+                        f"(threshold: {max_orphaned})."
+                    ),
+                    remediation=(
+                        f"Too many orphaned claimed beads ({count} > {max_orphaned}). "
+                        "Clear stale beads before starting a new run."
+                    ),
+                )
+            return CheckResult(
+                name="No stale in-progress issues",
+                status="warn",
+                message=f"{count} claimed bead(s) with no open PR bead: {issue_list}.",
+                remediation=(
+                    f"Claimed beads with no open PR bead: {issue_list}. "
+                    "Inspect and unclaim or re-dispatch these issues."
+                ),
+            )
+        except Exception:
+            pass  # fall through to GitHub-based check
+
+    # ------------------------------------------------------------------
+    # GitHub fallback (no bead store)
+    # ------------------------------------------------------------------
     issues_result = subprocess.run(
         [
             "gh",
@@ -512,7 +579,6 @@ def _check_orphaned_issues(config: Config) -> CheckResult:
             message="No in-progress issues found.",
         )
 
-    # Get open PRs to cross-reference by branch naming convention
     pr_result = subprocess.run(
         [
             "gh",
@@ -535,7 +601,6 @@ def _check_orphaned_issues(config: Config) -> CheckResult:
         except json.JSONDecodeError:
             pass
 
-    # Build set of issue numbers that have a corresponding open PR
     issues_with_prs: set[int] = set()
     for pr in open_prs:
         head_ref: str = pr.get("headRefName", "")
@@ -543,7 +608,6 @@ def _check_orphaned_issues(config: Config) -> CheckResult:
         if parts[0].isdigit():
             issues_with_prs.add(int(parts[0]))
 
-    # Orphaned = in-progress label, no open PR
     orphaned = [issue for issue in issues if issue["number"] not in issues_with_prs]
     count = len(orphaned)
 

--- a/src/brimstone/health.py
+++ b/src/brimstone/health.py
@@ -467,179 +467,59 @@ def _check_worktrees() -> CheckResult:
 
 
 def _check_orphaned_issues(config: Config) -> CheckResult:
-    """Check 6: No stale in-progress issues (claimed beads with no open PR bead).
+    """Check 6: Claimed beads with no active PR bead.
 
-    Uses the bead store when available (bead-first: ``state=claimed`` + no PR bead).
-    Falls back to GitHub ``in-progress`` label cross-referenced with open PRs when
-    no bead store is configured.
+    Beads are the source of truth — no GitHub API is consulted.
+    Claimed beads without a PR bead are always recoverable: ``_resume_stale_issues``
+    resets them to ``open`` on the next run. This check only warns; it never fails.
     """
-    max_orphaned: int = getattr(config, "max_orphaned_issues", 5)
     github_repo: str | None = getattr(config, "github_repo", None)
-
-    # ------------------------------------------------------------------
-    # Bead-based check (preferred)
-    # ------------------------------------------------------------------
-    if github_repo:
-        try:
-            store: BeadStore = make_bead_store(config, github_repo)
-            claimed_beads = store.list_work_beads(state="claimed")
-            if not claimed_beads:
-                return CheckResult(
-                    name="No stale in-progress issues",
-                    status="pass",
-                    message="No claimed beads found.",
-                )
-            # Issues with a PR bead in a non-terminal state have active PRs
-            issues_with_open_prs: set[int] = {
-                pb.issue_number
-                for pb in store.list_pr_beads()
-                if pb.state not in ("merged", "abandoned")
-            }
-            orphaned_beads = [
-                b for b in claimed_beads if b.issue_number not in issues_with_open_prs
-            ]
-            count = len(orphaned_beads)
-            total_claimed = len(claimed_beads)
-
-            if count == 0:
-                return CheckResult(
-                    name="No stale in-progress issues",
-                    status="pass",
-                    message=f"{total_claimed} claimed bead(s) all have open PR beads.",
-                )
-
-            issue_list = ", ".join(f"#{b.issue_number} '{b.title}'" for b in orphaned_beads)
-            if count > max_orphaned:
-                return CheckResult(
-                    name="No stale in-progress issues",
-                    status="fail",
-                    message=(
-                        f"Too many orphaned claimed beads: {count} with no open PR bead "
-                        f"(threshold: {max_orphaned})."
-                    ),
-                    remediation=(
-                        f"Too many orphaned claimed beads ({count} > {max_orphaned}). "
-                        "Clear stale beads before starting a new run."
-                    ),
-                )
-            return CheckResult(
-                name="No stale in-progress issues",
-                status="warn",
-                message=f"{count} claimed bead(s) with no open PR bead: {issue_list}.",
-                remediation=(
-                    f"Claimed beads with no open PR bead: {issue_list}. "
-                    "Inspect and unclaim or re-dispatch these issues."
-                ),
-            )
-        except Exception:
-            pass  # fall through to GitHub-based check
-
-    # ------------------------------------------------------------------
-    # GitHub fallback (no bead store)
-    # ------------------------------------------------------------------
-    issues_result = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--label",
-            "in-progress",
-            "--state",
-            "open",
-            "--json",
-            "number,title",
-            "--limit",
-            "100",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    if issues_result.returncode != 0:
+    if not github_repo:
         return CheckResult(
             name="No stale in-progress issues",
-            status="warn",
-            message="Could not list in-progress issues via gh.",
-            remediation=None,
+            status="pass",
+            message="No bead store configured — check skipped.",
         )
 
     try:
-        issues: list[dict] = json.loads(issues_result.stdout)
-    except json.JSONDecodeError:
+        store: BeadStore = make_bead_store(config, github_repo)
+    except Exception as exc:
         return CheckResult(
             name="No stale in-progress issues",
             status="warn",
-            message="Could not parse gh issue list output.",
-            remediation=None,
+            message=f"Could not open bead store: {exc}",
         )
 
-    if not issues:
+    claimed_beads = store.list_work_beads(state="claimed")
+    if not claimed_beads:
         return CheckResult(
             name="No stale in-progress issues",
             status="pass",
-            message="No in-progress issues found.",
+            message="No claimed beads found.",
         )
 
-    pr_result = subprocess.run(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--json",
-            "number,headRefName",
-            "--limit",
-            "100",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    open_prs: list[dict] = []
-    if pr_result.returncode == 0:
-        try:
-            open_prs = json.loads(pr_result.stdout)
-        except json.JSONDecodeError:
-            pass
+    issues_with_pr_bead: set[int] = {
+        pb.issue_number
+        for pb in store.list_pr_beads()
+        if pb.state not in ("merged", "abandoned")
+    }
 
-    issues_with_prs: set[int] = set()
-    for pr in open_prs:
-        head_ref: str = pr.get("headRefName", "")
-        parts = head_ref.split("-", 1)
-        if parts[0].isdigit():
-            issues_with_prs.add(int(parts[0]))
-
-    orphaned = [issue for issue in issues if issue["number"] not in issues_with_prs]
-    count = len(orphaned)
-
-    if count == 0:
+    orphaned = [b for b in claimed_beads if b.issue_number not in issues_with_pr_bead]
+    if not orphaned:
         return CheckResult(
             name="No stale in-progress issues",
             status="pass",
-            message=f"{len(issues)} in-progress issue(s) all have open PRs.",
+            message=f"{len(claimed_beads)} claimed bead(s) all have active PR beads.",
         )
 
-    if count > max_orphaned:
-        return CheckResult(
-            name="No stale in-progress issues",
-            status="fail",
-            message=(
-                f"Too many orphaned in-progress issues: {count} with no open PR "
-                f"(threshold: {max_orphaned})."
-            ),
-            remediation=(
-                f"Too many orphaned in-progress issues ({count} > {max_orphaned}). "
-                "Clear stale labels before starting a new run."
-            ),
-        )
-
-    issue_list = ", ".join(f"#{i['number']} '{i['title']}'" for i in orphaned)
+    issue_list = ", ".join(f"#{b.issue_number}" for b in orphaned)
     return CheckResult(
         name="No stale in-progress issues",
         status="warn",
-        message=f"{count} in-progress issue(s) with no open PR: {issue_list}.",
+        message=f"{len(orphaned)} claimed bead(s) with no PR bead: {issue_list}.",
         remediation=(
-            f"In-progress issues with no open PR: {issue_list}. "
-            "Inspect and remove the 'in-progress' label if stale."
+            "These beads will be reset to 'open' automatically when `brimstone run` resumes. "
+            "No manual action needed."
         ),
     )
 

--- a/src/brimstone/logger.py
+++ b/src/brimstone/logger.py
@@ -70,6 +70,7 @@ BRIMSTONE_EVENT_TYPES: frozenset[str] = frozenset(
         "agent_nuclear_restart",
         "agent_exception",
         "recovery_dispatched",
+        "dependency_pruned",
     }
 )
 

--- a/src/brimstone/logger.py
+++ b/src/brimstone/logger.py
@@ -65,6 +65,11 @@ BRIMSTONE_EVENT_TYPES: frozenset[str] = frozenset(
         "human_escalate",
         "checkpoint_write",
         "stage_complete",
+        "inline_comments_present",
+        "ci_monitoring_complete_no_merge",
+        "agent_nuclear_restart",
+        "agent_exception",
+        "recovery_dispatched",
     }
 )
 

--- a/src/brimstone/monitor.py
+++ b/src/brimstone/monitor.py
@@ -1,21 +1,45 @@
 """Brimstone monitor — continuous bead/repo health checks.
 
-Runs a detection loop that compares bead state against GitHub state and flags
-aberrations by filing GitHub issues. Designed to run as a long-lived side
-process alongside ``brimstone run``, or as a one-shot diagnostic with
-``brimstone monitor --once``.
+Runs a detection loop that compares bead state against GitHub state, bead-ifies
+every anomaly in the source repo's bead store, and responds in one of three tiers:
+
+  inline  — fix is trivial and deterministic; monitor applies it directly with no
+             issue filed (e.g. add/remove a GitHub label, insert a MergeQueue entry).
+
+  bug     — fix is known but requires agent execution; a ``stage/impl`` repair issue
+             is filed in the repo's ``repairs`` milestone so the normal impl pipeline
+             can pick it up.
+
+  probe   — the cause is unclear; a ``stage/research`` issue is filed in ``repairs``
+             so an agent can investigate before a fix is attempted.
+
+AnomalyBeads live in the source repo's bead store (``anomalies/<id>.json``).
+When brimstone watches multiple repos (``--watch``), each repo's anomaly beads stay
+in that repo's bead store and repair issues are filed in that repo's ``repairs``
+milestone — never cross-contaminated.
 
 Detector inventory
 ------------------
-check_label_drift       claimed bead <-> in-progress GitHub label mismatch
-check_dep_integrity     phantom deps (dep bead missing) + dep cycles
-check_state_regressions illegal bead-state transitions in event log
-check_orphaned_merge    merge_ready beads absent from the MergeQueue
-check_pre_pr_zombies    claimed beads older than timeout with no PRBead
+check_label_drift         claimed bead <-> in-progress GitHub label mismatch
+check_dep_integrity       phantom deps (dep bead missing) + dep cycles
+check_state_regressions   illegal bead-state transitions in event log
+check_orphaned_merge      merge_ready beads absent from the MergeQueue
+check_pre_pr_zombies      claimed beads older than timeout with no PRBead
+
+Repair tiers per anomaly kind
+------------------------------
+label_drift           inline   (add or remove the label)
+orphaned_merge        inline   (insert MergeQueue entry)
+pre_pr_zombie         bug      (create missing PR, or reset bead if branch gone)
+dep_cycle             probe    (which blocked_by edge is stale?)
+phantom_dep           probe    (was the dep intentionally removed?)
+state_regression      probe    (what caused the illegal transition?)
+detector_error        probe    (why did the detector itself fail?)
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import time
@@ -23,7 +47,13 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 
-from brimstone.beads import BeadStore, detect_dep_cycles
+from brimstone.beads import (
+    BEAD_SCHEMA_VERSION,
+    AnomalyBead,
+    BeadStore,
+    MergeQueueEntry,
+    detect_dep_cycles,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -32,6 +62,8 @@ from brimstone.beads import BeadStore, detect_dep_cycles
 MONITOR_INTERVAL_SECONDS: int = 60
 ZOMBIE_TIMEOUT_MINUTES: float = 90.0
 MONITOR_FILED_FILENAME: str = "monitor-filed.json"
+REPAIRS_MILESTONE: str = "repairs"
+INLINE_REPAIR_MAX_ATTEMPTS: int = 3  # escalate to bug after this many inline failures
 
 # Illegal state transitions: (from_state, to_state) pairs that must never appear
 _BAD_TRANSITIONS: frozenset[tuple[str | None, str]] = frozenset(
@@ -45,7 +77,6 @@ _BAD_TRANSITIONS: frozenset[tuple[str | None, str]] = frozenset(
     ]
 )
 
-
 # ---------------------------------------------------------------------------
 # Anomaly dataclass
 # ---------------------------------------------------------------------------
@@ -57,12 +88,17 @@ class Anomaly:
 
     Attributes
     ----------
-    kind:        Short machine-readable tag (e.g. ``"label_drift"``).
-    severity:    ``"warning"`` or ``"critical"``.
-    description: One-line human summary.
-    details:     Dict of supporting evidence (serialised into the filed issue).
-    needs_agent: True when the anomaly is ambiguous and benefits from a
-                 Claude agent's analysis before filing.
+    kind:         Short machine-readable tag (e.g. ``"label_drift"``).
+    severity:     ``"warning"`` or ``"critical"``.
+    description:  One-line human summary.
+    details:      Dict of supporting evidence (serialised into the filed issue).
+    needs_agent:  Kept for backward compatibility; superseded by ``repair_tier``.
+    is_blocking:  True when this anomaly can prevent the active milestone from
+                  making forward progress — set by ``classify_blocking()``.
+    repair_tier:  How the monitor responds:
+                  ``"inline"``  — fix applied directly, no issue filed
+                  ``"bug"``     — ``stage/impl`` issue in ``repairs`` milestone
+                  ``"probe"``   — ``stage/research`` issue in ``repairs`` milestone
     """
 
     kind: str
@@ -70,12 +106,90 @@ class Anomaly:
     description: str
     details: dict = field(default_factory=dict)
     needs_agent: bool = False
+    is_blocking: bool = False
+    repair_tier: str = "probe"  # "inline" | "bug" | "probe"
 
     def fingerprint(self) -> str:
         """Stable string key used for dedup (kind + primary detail values)."""
-        # Sort details to ensure key order doesn't affect fingerprint
         detail_str = json.dumps(self.details, sort_keys=True)
         return f"{self.kind}:{detail_str}"
+
+
+# ---------------------------------------------------------------------------
+# Anomaly ID
+# ---------------------------------------------------------------------------
+
+
+def _anomaly_id(anomaly: Anomaly) -> str:
+    """Return a stable 16-char hex ID: first 16 chars of SHA-256(fingerprint)."""
+    return hashlib.sha256(anomaly.fingerprint().encode()).hexdigest()[:16]
+
+
+# ---------------------------------------------------------------------------
+# Active-milestone helper
+# ---------------------------------------------------------------------------
+
+
+def _get_active_milestone(store: BeadStore) -> str | None:
+    """Return the name of the currently-active campaign milestone, or None."""
+    campaign = store.read_campaign_bead()
+    if campaign is None:
+        return None
+    for ms in campaign.milestones[campaign.current_index :]:
+        if campaign.statuses.get(ms) != "shipped":
+            return ms
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify_blocking(
+    anomaly: Anomaly,
+    store: BeadStore,
+    active_milestone: str | None,
+) -> bool:
+    """Return True when this anomaly can prevent the active milestone from progressing."""
+    kind = anomaly.kind
+
+    if kind in ("dep_cycle", "phantom_dep", "state_regression", "orphaned_merge"):
+        return True
+
+    if kind == "detector_error":
+        return False
+
+    if kind == "pre_pr_zombie":
+        if active_milestone is None:
+            return False
+        issue_number = anomaly.details.get("issue_number")
+        if issue_number is None:
+            return False
+        bead = store.read_work_bead(issue_number)
+        return bead is not None and bead.milestone == active_milestone
+
+    if kind == "label_drift":
+        # Only blocking when a terminal bead still carries the active label —
+        # a zombie label could fool the orchestrator into skipping a re-dispatch.
+        bead_state = anomaly.details.get("bead_state")
+        has_label = anomaly.details.get("has_label", False)
+        return has_label and bead_state in ("closed", "abandoned")
+
+    return False
+
+
+def classify_repair_tier(anomaly: Anomaly) -> str:
+    """Return the repair tier for *anomaly* (pure function of kind + details)."""
+    kind = anomaly.kind
+    # Inline: trivially safe, reversible operations the monitor can do itself
+    if kind in ("label_drift", "orphaned_merge"):
+        return "inline"
+    # Bug: fix is known, an impl agent can execute it without research
+    if kind == "pre_pr_zombie":
+        return "bug"
+    # Everything else: cause is unclear, needs investigation first
+    return "probe"
 
 
 # ---------------------------------------------------------------------------
@@ -84,14 +198,9 @@ class Anomaly:
 
 
 def check_label_drift(store: BeadStore, repo: str) -> list[Anomaly]:
-    """Detect claimed beads without in-progress label (and vice-versa).
-
-    A bead in state ``claimed`` should have the ``in-progress`` GitHub label.
-    A bead NOT in state ``claimed`` should NOT have the label.
-    """
+    """Detect claimed beads without in-progress label (and vice-versa)."""
     anomalies: list[Anomaly] = []
 
-    # Fetch all issues with in-progress label
     result = _gh(
         [
             "issue",
@@ -118,7 +227,6 @@ def check_label_drift(store: BeadStore, repo: str) -> list[Anomaly]:
     claimed_beads = store.list_work_beads(state="claimed")
     claimed_numbers = {b.issue_number for b in claimed_beads}
 
-    # claimed bead but missing in-progress label
     for num in claimed_numbers - in_progress_numbers:
         anomalies.append(
             Anomaly(
@@ -129,15 +237,10 @@ def check_label_drift(store: BeadStore, repo: str) -> list[Anomaly]:
             )
         )
 
-    # in-progress label but no claimed bead (or bead in non-claimed state)
     for num in in_progress_numbers - claimed_numbers:
         bead = store.read_work_bead(num)
         bead_state = bead.state if bead else None
-        if bead_state in ("closed", "abandoned", "merge_ready"):
-            # These are important to flag
-            severity = "critical" if bead_state in ("closed", "abandoned") else "warning"
-        else:
-            severity = "warning"
+        severity = "critical" if bead_state in ("closed", "abandoned") else "warning"
         anomalies.append(
             Anomaly(
                 kind="label_drift",
@@ -190,7 +293,7 @@ def check_dep_integrity(store: BeadStore) -> list[Anomaly]:
 
 
 def check_state_regressions(store: BeadStore) -> list[Anomaly]:
-    """Detect illegal state transitions in event logs (e.g. merge_ready -> open)."""
+    """Detect illegal state transitions in event logs."""
     anomalies: list[Anomaly] = []
     all_beads = store.list_work_beads()
 
@@ -216,7 +319,7 @@ def check_state_regressions(store: BeadStore) -> list[Anomaly]:
                         },
                     )
                 )
-            prev_state = ev.to_state  # noqa: F841 (used for future checks)
+            prev_state = ev.to_state  # noqa: F841
 
     return anomalies
 
@@ -257,16 +360,13 @@ def check_pre_pr_zombies(
 
     for bead in claimed_beads:
         if bead.pr_id is not None:
-            continue  # has a PR, not a zombie
-
+            continue
         if bead.claimed_at is None:
-            continue  # no claim timestamp; can't determine age
-
+            continue
         try:
             claimed_dt = datetime.fromisoformat(bead.claimed_at)
         except ValueError:
             continue
-
         age_minutes = (now - claimed_dt).total_seconds() / 60
         if age_minutes >= timeout_minutes:
             anomalies.append(
@@ -310,7 +410,6 @@ def run_all_detectors(store: BeadStore, repo: str) -> list[Anomaly]:
             found = detector(store, repo)
             anomalies.extend(found)
         except Exception as exc:  # noqa: BLE001
-            # Never let a detector crash the monitor loop
             anomalies.append(
                 Anomaly(
                     kind="detector_error",
@@ -323,27 +422,213 @@ def run_all_detectors(store: BeadStore, repo: str) -> list[Anomaly]:
 
 
 # ---------------------------------------------------------------------------
-# Dedup / filing
+# Inline repair actions
 # ---------------------------------------------------------------------------
 
 
-def _load_filed(beads_dir: Path) -> dict[str, str]:
-    """Load the monitor-filed.json dedup map {fingerprint: issue_url}."""
-    path = beads_dir / MONITOR_FILED_FILENAME
-    if not path.exists():
-        return {}
+def _inline_repair_label_drift(anomaly: Anomaly, repo: str) -> bool:
+    """Add or remove the in-progress label to match bead state."""
+    issue_number = anomaly.details.get("issue_number")
+    has_label = anomaly.details.get("has_label", False)
+    if issue_number is None:
+        return False
+    flag = "--remove-label" if has_label else "--add-label"
+    result = _gh(
+        ["issue", "edit", str(issue_number), flag, "in-progress"],
+        repo=repo,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _inline_repair_orphaned_merge(anomaly: Anomaly, store: BeadStore) -> bool:
+    """Insert the missing MergeQueue entry for a merge_ready bead."""
+    issue_number = anomaly.details.get("issue_number")
+    if issue_number is None:
+        return False
+    bead = store.read_work_bead(issue_number)
+    if bead is None or bead.pr_id is None:
+        return False
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
-        return {}
+        pr_number = int(bead.pr_id.replace("pr-", ""))
+    except ValueError:
+        return False
+    queue = store.read_merge_queue()
+    if any(e.issue_number == issue_number for e in queue.queue):
+        return True  # already present; anomaly will clear on next scan
+    entry = MergeQueueEntry(
+        pr_number=pr_number,
+        issue_number=issue_number,
+        branch=bead.branch,
+        enqueued_at=datetime.now(UTC).isoformat(),
+        priority=0,
+    )
+    queue.queue.append(entry)
+    queue.updated_at = datetime.now(UTC).isoformat()
+    store.write_merge_queue(queue)
+    return True
 
 
-def _save_filed(beads_dir: Path, filed: dict[str, str]) -> None:
-    """Atomically write the monitor-filed.json dedup map."""
-    path = beads_dir / MONITOR_FILED_FILENAME
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(filed, indent=2), encoding="utf-8")
-    tmp.replace(path)
+def _apply_inline_repair(anomaly: Anomaly, store: BeadStore, repo: str) -> bool:
+    """Dispatch to the correct inline-repair handler. Returns True on success."""
+    if anomaly.kind == "label_drift":
+        return _inline_repair_label_drift(anomaly, repo)
+    if anomaly.kind == "orphaned_merge":
+        return _inline_repair_orphaned_merge(anomaly, store)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Repair issue filing (bug + probe tiers)
+# ---------------------------------------------------------------------------
+
+_REPAIR_CHECKLISTS: dict[str, str] = {
+    "pre_pr_zombie": (
+        "- [ ] Check whether the agent branch (`{branch}`) exists on the remote\n"
+        "- [ ] If branch has commits: `gh pr create --head {branch}` to recover the PR\n"
+        "- [ ] If branch is empty or missing: reset bead state to `open` for re-dispatch\n"
+        "  (`jq '.state = \"open\" | .pr_id = null | .claimed_at = null' "
+        "~/.brimstone/beads/{repo}/work/{issue_number}.json > tmp && mv tmp ...`)\n"
+        "- [ ] Verify: `brimstone monitor --once --dry-run --repo {repo}`"
+    ),
+    "dep_cycle": (
+        "## Investigation\n\n"
+        "- [ ] List all issues in the cycle (see details above)\n"
+        "- [ ] For each `blocked_by` edge in the cycle, check whether the dependency\n"
+        "  is still valid or was superseded\n"
+        "- [ ] Remove the stale `blocked_by` entry from the WorkBead JSON\n"
+        "- [ ] Verify: `brimstone monitor --once --dry-run --repo {repo}`"
+    ),
+    "phantom_dep": (
+        "## Investigation\n\n"
+        "- [ ] Check if issue #{phantom_dep} was intentionally closed/deleted\n"
+        "- [ ] If stale reference: remove `{phantom_dep}` from issue "
+        "#{issue_number}'s `blocked_by`\n"
+        "- [ ] If genuinely missing: re-file the dependency issue and create its "
+        "WorkBead\n"
+        "- [ ] Verify: `brimstone monitor --once --dry-run --repo {repo}`"
+    ),
+    "state_regression": (
+        "## Investigation\n\n"
+        "- [ ] Read the event log: "
+        "`cat ~/.brimstone/beads/{repo}/events/work-{issue_number}.jsonl`\n"
+        "- [ ] Identify what caused the illegal `{from_state}` → `{to_state}` transition\n"
+        "- [ ] If bead is corrupted: restore last valid state from event log\n"
+        "- [ ] Document the root cause in a comment on this issue\n"
+        "- [ ] Verify: `brimstone monitor --once --dry-run --repo {repo}`"
+    ),
+    "detector_error": (
+        "## Investigation\n\n"
+        "- [ ] Identify which detector raised: `{detector}`\n"
+        "- [ ] Find the exception in monitor logs: `{error}`\n"
+        "- [ ] Fix the detector or add a guard around the failing code path\n"
+        "- [ ] Verify: `brimstone monitor --once --dry-run --repo {repo}`"
+    ),
+}
+
+
+def _repair_checklist(anomaly: Anomaly, repo: str) -> str:
+    template = _REPAIR_CHECKLISTS.get(
+        anomaly.kind,
+        "- [ ] Investigate the anomaly details above and resolve manually.",
+    )
+    # Fill in detail placeholders where present
+    ctx = {"repo": repo, **anomaly.details}
+    try:
+        return template.format(**ctx)
+    except KeyError:
+        return template
+
+
+def _get_repairs_milestone_number(repo: str) -> int | None:
+    """Return the GH milestone number for the ``repairs`` milestone, or None."""
+    result = _gh(
+        [
+            "api",
+            f"repos/{repo}/milestones",
+            "--jq",
+            f'[.[] | select(.title=="{REPAIRS_MILESTONE}")] | first | .number',
+        ],
+        repo=None,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    raw = result.stdout.strip()
+    if not raw or raw == "null":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _build_repair_issue_body(anomaly: Anomaly, repo: str) -> str:
+    details_block = json.dumps(anomaly.details, indent=2)
+    checklist = _repair_checklist(anomaly, repo)
+    blocking_str = "**yes — build may stall**" if anomaly.is_blocking else "no"
+    tier_label = {"bug": "impl (fix known)", "probe": "research (investigate first)"}.get(
+        anomaly.repair_tier, anomaly.repair_tier
+    )
+    return (
+        f"## Monitor Anomaly: `{anomaly.kind}`\n\n"
+        f"**Severity:** {anomaly.severity}  \n"
+        f"**Is blocking:** {blocking_str}  \n"
+        f"**Repair tier:** {tier_label}  \n"
+        f"**Anomaly ID:** `{_anomaly_id(anomaly)}`\n\n"
+        f"**Description:** {anomaly.description}\n\n"
+        f"## Details\n"
+        f"```json\n{details_block}\n```\n\n"
+        f"## Checklist\n\n"
+        f"{checklist}\n\n"
+        f"*Filed automatically by `brimstone monitor`.*"
+    )
+
+
+def _file_repair_issue(anomaly: Anomaly, repo: str) -> str | None:
+    """File a bug or probe repair issue in the repo's ``repairs`` milestone.
+
+    Returns the issue URL on success, None on failure.
+    """
+    ms_number = _get_repairs_milestone_number(repo)
+    if ms_number is None:
+        print(
+            f"[monitor] WARN: '{REPAIRS_MILESTONE}' milestone missing in {repo}; "
+            f"run 'brimstone monitor --init --repo={repo}' to create it"
+        )
+        return None
+
+    priority = "P0" if anomaly.is_blocking else "P2"
+    stage = "stage/impl" if anomaly.repair_tier == "bug" else "stage/research"
+    labels = f"bug,{priority},{stage}"
+    title = f"[monitor/{anomaly.repair_tier}] {anomaly.kind}: {anomaly.description[:80]}"
+    body = _build_repair_issue_body(anomaly, repo)
+
+    result = _gh(
+        [
+            "issue",
+            "create",
+            "--title",
+            title,
+            "--label",
+            labels,
+            "--milestone",
+            str(ms_number),
+            "--body",
+            body,
+        ],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    return url if url else None
+
+
+# ---------------------------------------------------------------------------
+# Legacy issue filing (kept for backward compatibility)
+# ---------------------------------------------------------------------------
 
 
 def _build_issue_body(anomaly: Anomaly) -> str:
@@ -358,66 +643,186 @@ def _build_issue_body(anomaly: Anomaly) -> str:
     )
 
 
-def file_anomaly_issue(anomaly: Anomaly, bugs_repo: str) -> str | None:
-    """File a GitHub issue for the anomaly. Returns the issue URL or None on failure."""
+def file_anomaly_issue(anomaly: Anomaly, repo: str) -> str | None:
+    """File a GitHub issue for the anomaly (legacy path, no AnomalyBead).
+
+    Prefer ``_file_repair_issue`` for new callers.
+    Returns the issue URL or None on failure.
+    """
     label = "bug,P1" if anomaly.severity == "critical" else "bug,P2"
     title = f"[monitor] {anomaly.kind}: {anomaly.description[:80]}"
     body = _build_issue_body(anomaly)
-
     result = _gh(
         ["issue", "create", "--title", title, "--label", label, "--body", body],
-        repo=bugs_repo,
+        repo=repo,
         check=False,
     )
     if result.returncode != 0:
         return None
-    # gh issue create prints the URL on stdout
     url = result.stdout.strip()
     return url if url else None
+
+
+# ---------------------------------------------------------------------------
+# Dedup / processing
+# ---------------------------------------------------------------------------
+
+
+def _load_filed(beads_dir: Path) -> dict[str, str]:
+    """Load the legacy monitor-filed.json dedup map {fingerprint: issue_url}."""
+    path = beads_dir / MONITOR_FILED_FILENAME
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_filed(beads_dir: Path, filed: dict[str, str]) -> None:
+    """Atomically write the monitor-filed.json dedup map (legacy)."""
+    path = beads_dir / MONITOR_FILED_FILENAME
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(filed, indent=2), encoding="utf-8")
+    tmp.replace(path)
 
 
 def process_anomalies(
     anomalies: list[Anomaly],
     store: BeadStore,
-    bugs_repo: str,
+    repo: str,
     dry_run: bool = False,
+    # bugs_repo kept for backward compat but ignored — issues go to repo's repairs milestone
+    bugs_repo: str | None = None,  # noqa: ARG001
 ) -> list[str]:
-    """Dedup and file GitHub issues for each new anomaly.
+    """Classify, bead-ify, and respond to each detected anomaly.
 
-    Args:
-        anomalies: Detected anomalies from this scan pass.
-        store:     BeadStore for the watched repo (used for dedup file path).
-        bugs_repo: Repository where bug issues are filed (the brimstone repo,
-                   not the target repo being orchestrated).
-        dry_run:   Print anomalies without filing GitHub issues.
+    For each anomaly:
+    - Sets ``is_blocking`` and ``repair_tier`` on the Anomaly object.
+    - Creates an AnomalyBead in the source repo's bead store (dedup by anomaly_id).
+    - ``inline``: applies the fix directly, no issue filed.
+    - ``bug``: files a ``stage/impl`` issue in repo's ``repairs`` milestone.
+    - ``probe``: files a ``stage/research`` issue in repo's ``repairs`` milestone.
 
-    Returns a list of URLs for issues filed this run.
+    Also runs a cleanup sweep: AnomalyBeads in ``open`` state whose anomaly no
+    longer appears are transitioned to ``repaired``.
+
+    Returns a list of URLs for repair issues filed this run.
     """
-    beads_dir = store._beads_dir
-    filed = _load_filed(beads_dir)
+    active_milestone = _get_active_milestone(store)
+
+    for anomaly in anomalies:
+        anomaly.is_blocking = classify_blocking(anomaly, store, active_milestone)
+        anomaly.repair_tier = classify_repair_tier(anomaly)
+
+    current_ids = {_anomaly_id(a) for a in anomalies}
+
+    # Cleanup sweep: mark resolved AnomalyBeads
+    for abead in store.list_anomaly_beads(state="open"):
+        if abead.anomaly_id not in current_ids:
+            abead.state = "repaired"
+            abead.resolved_at = datetime.now(UTC).isoformat()
+            store.write_anomaly_bead(abead)
+            print(f"[monitor] anomaly {abead.anomaly_id} ({abead.kind}) resolved")
+
+    # Legacy fallback: fingerprints already filed before AnomalyBeads existed
+    legacy_filed = _load_filed(store._beads_dir)
     new_urls: list[str] = []
 
     for anomaly in anomalies:
+        aid = _anomaly_id(anomaly)
         fp = anomaly.fingerprint()
-        if fp in filed:
-            continue  # already filed
 
-        if dry_run:
-            desc = anomaly.description
-            print(f"[monitor/dry-run] {anomaly.severity.upper()} {anomaly.kind}: {desc}")
-            filed[fp] = "dry-run"
+        existing = store.read_anomaly_bead(aid)
+
+        # Skip terminal anomalies
+        if existing and existing.state in ("repaired", "wont_fix"):
             continue
 
-        url = file_anomaly_issue(anomaly, bugs_repo)
-        if url:
-            filed[fp] = url
-            new_urls.append(url)
-            print(f"[monitor] filed {anomaly.severity} issue: {url}")
-        else:
-            print(f"[monitor] WARN: failed to file issue for {anomaly.kind!r}")
+        # Skip anomalies covered by legacy dedup
+        if existing is None and fp in legacy_filed:
+            continue
 
-    if not dry_run:
-        _save_filed(beads_dir, filed)
+        if dry_run:
+            status = "BLOCKING" if anomaly.is_blocking else "non-blocking"
+            print(
+                f"[monitor/dry-run] {status} {anomaly.repair_tier.upper()} "
+                f"{anomaly.kind}: {anomaly.description}"
+            )
+            continue
+
+        # Create AnomalyBead if new
+        if existing is None:
+            existing = AnomalyBead(
+                v=BEAD_SCHEMA_VERSION,
+                anomaly_id=aid,
+                source_repo=repo,
+                kind=anomaly.kind,
+                severity=anomaly.severity,
+                is_blocking=anomaly.is_blocking,
+                repair_tier=anomaly.repair_tier,
+                description=anomaly.description,
+                details=anomaly.details,
+                state="open",
+                auto_repair_attempts=0,
+                detected_at=datetime.now(UTC).isoformat(),
+            )
+            store.write_anomaly_bead(existing)
+            print(f"[monitor] new anomaly {aid} ({anomaly.kind}, {anomaly.repair_tier})")
+
+        # --- Inline tier ---
+        if anomaly.repair_tier == "inline":
+            success = _apply_inline_repair(anomaly, store, repo)
+            existing.auto_repair_attempts += 1
+            store.write_anomaly_bead(existing)
+            if success:
+                print(f"[monitor] inline repair applied for {aid} ({anomaly.kind})")
+            else:
+                attempts = existing.auto_repair_attempts
+                print(
+                    f"[monitor] inline repair attempt {attempts} failed for {aid} ({anomaly.kind})"
+                )
+                if attempts >= INLINE_REPAIR_MAX_ATTEMPTS:
+                    # Escalate to bug
+                    print(
+                        f"[monitor] escalating {aid} to bug after "
+                        f"{INLINE_REPAIR_MAX_ATTEMPTS} failed inline attempts"
+                    )
+                    anomaly.repair_tier = "bug"
+                    existing.repair_tier = "bug"
+                    url = _file_repair_issue(anomaly, repo)
+                    if url:
+                        existing.gh_issue_url = url
+                        try:
+                            existing.gh_issue_number = int(url.rstrip("/").split("/")[-1])
+                        except ValueError:
+                            pass
+                        store.write_anomaly_bead(existing)
+                        new_urls.append(url)
+                        print(f"[monitor] escalated bug issue filed: {url}")
+
+        # --- Bug / Probe tiers ---
+        else:
+            if existing.gh_issue_number is None:
+                url = _file_repair_issue(anomaly, repo)
+                if url:
+                    existing.gh_issue_url = url
+                    try:
+                        existing.gh_issue_number = int(url.rstrip("/").split("/")[-1])
+                    except ValueError:
+                        pass
+                    store.write_anomaly_bead(existing)
+                    new_urls.append(url)
+                    print(
+                        f"[monitor] {anomaly.repair_tier} issue filed: {url} "
+                        f"({'blocking' if anomaly.is_blocking else 'non-blocking'})"
+                    )
+                else:
+                    print(
+                        f"[monitor] WARN: failed to file {anomaly.repair_tier} "
+                        f"issue for {anomaly.kind!r}"
+                    )
+
     return new_urls
 
 
@@ -430,7 +835,7 @@ def run_monitor(
     store: BeadStore,
     repo: str,
     *,
-    bugs_repo: str | None = None,
+    bugs_repo: str | None = None,  # kept for backward compat; ignored
     once: bool = False,
     interval: int = MONITOR_INTERVAL_SECONDS,
     dry_run: bool = False,
@@ -438,19 +843,15 @@ def run_monitor(
     """Run the monitoring loop.
 
     Args:
-        store:     BeadStore for the target repo being orchestrated.
-        repo:      ``owner/repo`` of the target repo (used for label checks).
-        bugs_repo: ``owner/repo`` where anomaly issues are filed.  Defaults to
-                   ``repo`` when not set, but should normally be the brimstone
-                   repo itself since anomalies represent brimstone bugs.
+        store:     BeadStore for the target repo.
+        repo:      ``owner/repo`` string (for GitHub API calls).
+        bugs_repo: Deprecated; ignored. Repair issues are now filed in each
+                   repo's own ``repairs`` milestone, not a central bugs repo.
         once:      If True, run one pass and return instead of looping.
         interval:  Seconds between detection passes.
-        dry_run:   If True, print anomalies but do not file GitHub issues.
+        dry_run:   If True, print anomalies but do not write beads or file issues.
     """
-    _bugs_repo = bugs_repo or repo
-    print(
-        f"[monitor] watching {repo}, filing bugs → {_bugs_repo} (interval={interval}s, once={once})"
-    )
+    print(f"[monitor] starting for {repo} (interval={interval}s, once={once})")
 
     while True:
         ts = datetime.now(UTC).isoformat()
@@ -459,10 +860,14 @@ def run_monitor(
         anomalies = run_all_detectors(store, repo)
 
         if anomalies:
-            new_urls = process_anomalies(anomalies, store, _bugs_repo, dry_run=dry_run)
+            new_urls = process_anomalies(anomalies, store, repo, dry_run=dry_run)
             total = len(anomalies)
             new = len(new_urls)
-            print(f"[monitor] {total} anomaly/ies found, {new} new issue(s) filed")
+            blocking = sum(1 for a in anomalies if a.is_blocking)
+            print(
+                f"[monitor] {total} anomaly/ies found "
+                f"({blocking} blocking), {new} new issue(s) filed"
+            )
         else:
             print("[monitor] clean — no anomalies")
 

--- a/src/brimstone/monitor.py
+++ b/src/brimstone/monitor.py
@@ -358,7 +358,7 @@ def _build_issue_body(anomaly: Anomaly) -> str:
     )
 
 
-def file_anomaly_issue(anomaly: Anomaly, repo: str) -> str | None:
+def file_anomaly_issue(anomaly: Anomaly, bugs_repo: str) -> str | None:
     """File a GitHub issue for the anomaly. Returns the issue URL or None on failure."""
     label = "bug,P1" if anomaly.severity == "critical" else "bug,P2"
     title = f"[monitor] {anomaly.kind}: {anomaly.description[:80]}"
@@ -366,7 +366,7 @@ def file_anomaly_issue(anomaly: Anomaly, repo: str) -> str | None:
 
     result = _gh(
         ["issue", "create", "--title", title, "--label", label, "--body", body],
-        repo=repo,
+        repo=bugs_repo,
         check=False,
     )
     if result.returncode != 0:
@@ -379,10 +379,17 @@ def file_anomaly_issue(anomaly: Anomaly, repo: str) -> str | None:
 def process_anomalies(
     anomalies: list[Anomaly],
     store: BeadStore,
-    repo: str,
+    bugs_repo: str,
     dry_run: bool = False,
 ) -> list[str]:
     """Dedup and file GitHub issues for each new anomaly.
+
+    Args:
+        anomalies: Detected anomalies from this scan pass.
+        store:     BeadStore for the watched repo (used for dedup file path).
+        bugs_repo: Repository where bug issues are filed (the brimstone repo,
+                   not the target repo being orchestrated).
+        dry_run:   Print anomalies without filing GitHub issues.
 
     Returns a list of URLs for issues filed this run.
     """
@@ -401,7 +408,7 @@ def process_anomalies(
             filed[fp] = "dry-run"
             continue
 
-        url = file_anomaly_issue(anomaly, repo)
+        url = file_anomaly_issue(anomaly, bugs_repo)
         if url:
             filed[fp] = url
             new_urls.append(url)
@@ -423,6 +430,7 @@ def run_monitor(
     store: BeadStore,
     repo: str,
     *,
+    bugs_repo: str | None = None,
     once: bool = False,
     interval: int = MONITOR_INTERVAL_SECONDS,
     dry_run: bool = False,
@@ -430,13 +438,19 @@ def run_monitor(
     """Run the monitoring loop.
 
     Args:
-        store:    BeadStore for the target repo.
-        repo:     ``owner/repo`` string (for GitHub API calls).
-        once:     If True, run one pass and return instead of looping.
-        interval: Seconds between detection passes.
-        dry_run:  If True, print anomalies but do not file GitHub issues.
+        store:     BeadStore for the target repo being orchestrated.
+        repo:      ``owner/repo`` of the target repo (used for label checks).
+        bugs_repo: ``owner/repo`` where anomaly issues are filed.  Defaults to
+                   ``repo`` when not set, but should normally be the brimstone
+                   repo itself since anomalies represent brimstone bugs.
+        once:      If True, run one pass and return instead of looping.
+        interval:  Seconds between detection passes.
+        dry_run:   If True, print anomalies but do not file GitHub issues.
     """
-    print(f"[monitor] starting for {repo} (interval={interval}s, once={once})")
+    _bugs_repo = bugs_repo or repo
+    print(
+        f"[monitor] watching {repo}, filing bugs → {_bugs_repo} (interval={interval}s, once={once})"
+    )
 
     while True:
         ts = datetime.now(UTC).isoformat()
@@ -445,7 +459,7 @@ def run_monitor(
         anomalies = run_all_detectors(store, repo)
 
         if anomalies:
-            new_urls = process_anomalies(anomalies, store, repo, dry_run=dry_run)
+            new_urls = process_anomalies(anomalies, store, _bugs_repo, dry_run=dry_run)
             total = len(anomalies)
             new = len(new_urls)
             print(f"[monitor] {total} anomaly/ies found, {new} new issue(s) filed")

--- a/src/brimstone/monitor.py
+++ b/src/brimstone/monitor.py
@@ -1,0 +1,474 @@
+"""Brimstone monitor — continuous bead/repo health checks.
+
+Runs a detection loop that compares bead state against GitHub state and flags
+aberrations by filing GitHub issues. Designed to run as a long-lived side
+process alongside ``brimstone run``, or as a one-shot diagnostic with
+``brimstone monitor --once``.
+
+Detector inventory
+------------------
+check_label_drift       claimed bead <-> in-progress GitHub label mismatch
+check_dep_integrity     phantom deps (dep bead missing) + dep cycles
+check_state_regressions illegal bead-state transitions in event log
+check_orphaned_merge    merge_ready beads absent from the MergeQueue
+check_pre_pr_zombies    claimed beads older than timeout with no PRBead
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from brimstone.beads import BeadStore, detect_dep_cycles
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MONITOR_INTERVAL_SECONDS: int = 60
+ZOMBIE_TIMEOUT_MINUTES: float = 90.0
+MONITOR_FILED_FILENAME: str = "monitor-filed.json"
+
+# Illegal state transitions: (from_state, to_state) pairs that must never appear
+_BAD_TRANSITIONS: frozenset[tuple[str | None, str]] = frozenset(
+    [
+        ("merge_ready", "open"),
+        ("merge_ready", "claimed"),
+        ("closed", "open"),
+        ("closed", "claimed"),
+        ("abandoned", "open"),
+        ("abandoned", "claimed"),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Anomaly dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Anomaly:
+    """A single detected aberration in bead or repo state.
+
+    Attributes
+    ----------
+    kind:        Short machine-readable tag (e.g. ``"label_drift"``).
+    severity:    ``"warning"`` or ``"critical"``.
+    description: One-line human summary.
+    details:     Dict of supporting evidence (serialised into the filed issue).
+    needs_agent: True when the anomaly is ambiguous and benefits from a
+                 Claude agent's analysis before filing.
+    """
+
+    kind: str
+    severity: str  # "warning" | "critical"
+    description: str
+    details: dict = field(default_factory=dict)
+    needs_agent: bool = False
+
+    def fingerprint(self) -> str:
+        """Stable string key used for dedup (kind + primary detail values)."""
+        # Sort details to ensure key order doesn't affect fingerprint
+        detail_str = json.dumps(self.details, sort_keys=True)
+        return f"{self.kind}:{detail_str}"
+
+
+# ---------------------------------------------------------------------------
+# Detectors
+# ---------------------------------------------------------------------------
+
+
+def check_label_drift(store: BeadStore, repo: str) -> list[Anomaly]:
+    """Detect claimed beads without in-progress label (and vice-versa).
+
+    A bead in state ``claimed`` should have the ``in-progress`` GitHub label.
+    A bead NOT in state ``claimed`` should NOT have the label.
+    """
+    anomalies: list[Anomaly] = []
+
+    # Fetch all issues with in-progress label
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--label",
+            "in-progress",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number",
+        ],
+        repo=repo,
+        check=False,
+    )
+    in_progress_numbers: set[int] = set()
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            in_progress_numbers = {i["number"] for i in json.loads(result.stdout)}
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    claimed_beads = store.list_work_beads(state="claimed")
+    claimed_numbers = {b.issue_number for b in claimed_beads}
+
+    # claimed bead but missing in-progress label
+    for num in claimed_numbers - in_progress_numbers:
+        anomalies.append(
+            Anomaly(
+                kind="label_drift",
+                severity="warning",
+                description=f"Issue #{num} has claimed bead but missing in-progress label",
+                details={"issue_number": num, "bead_state": "claimed", "has_label": False},
+            )
+        )
+
+    # in-progress label but no claimed bead (or bead in non-claimed state)
+    for num in in_progress_numbers - claimed_numbers:
+        bead = store.read_work_bead(num)
+        bead_state = bead.state if bead else None
+        if bead_state in ("closed", "abandoned", "merge_ready"):
+            # These are important to flag
+            severity = "critical" if bead_state in ("closed", "abandoned") else "warning"
+        else:
+            severity = "warning"
+        anomalies.append(
+            Anomaly(
+                kind="label_drift",
+                severity=severity,
+                description=(
+                    f"Issue #{num} has in-progress label but bead state is "
+                    f"{bead_state!r} (not claimed)"
+                ),
+                details={"issue_number": num, "bead_state": bead_state, "has_label": True},
+            )
+        )
+
+    return anomalies
+
+
+def check_dep_integrity(store: BeadStore) -> list[Anomaly]:
+    """Detect phantom deps (referenced issue has no bead) and dep cycles."""
+    anomalies: list[Anomaly] = []
+    all_beads = store.list_work_beads()
+    known = {b.issue_number for b in all_beads}
+
+    for bead in all_beads:
+        if bead.state in ("closed", "abandoned"):
+            continue
+        for dep in bead.blocked_by:
+            if dep not in known:
+                anomalies.append(
+                    Anomaly(
+                        kind="phantom_dep",
+                        severity="critical",
+                        description=(
+                            f"Issue #{bead.issue_number} blocked_by #{dep} but #{dep} has no bead"
+                        ),
+                        details={"issue_number": bead.issue_number, "phantom_dep": dep},
+                    )
+                )
+
+    cycles = detect_dep_cycles(all_beads)
+    for cycle in cycles:
+        anomalies.append(
+            Anomaly(
+                kind="dep_cycle",
+                severity="critical",
+                description=f"Dependency cycle detected: {' -> '.join(str(n) for n in cycle)}",
+                details={"cycle": cycle},
+            )
+        )
+
+    return anomalies
+
+
+def check_state_regressions(store: BeadStore) -> list[Anomaly]:
+    """Detect illegal state transitions in event logs (e.g. merge_ready -> open)."""
+    anomalies: list[Anomaly] = []
+    all_beads = store.list_work_beads()
+
+    for bead in all_beads:
+        events = store.read_events("work", str(bead.issue_number))
+        prev_state: str | None = None
+        for ev in events:
+            transition = (ev.from_state, ev.to_state)
+            if transition in _BAD_TRANSITIONS:
+                anomalies.append(
+                    Anomaly(
+                        kind="state_regression",
+                        severity="critical",
+                        description=(
+                            f"Issue #{bead.issue_number} illegal transition "
+                            f"{ev.from_state!r} -> {ev.to_state!r} at {ev.ts}"
+                        ),
+                        details={
+                            "issue_number": bead.issue_number,
+                            "from_state": ev.from_state,
+                            "to_state": ev.to_state,
+                            "ts": ev.ts,
+                        },
+                    )
+                )
+            prev_state = ev.to_state  # noqa: F841 (used for future checks)
+
+    return anomalies
+
+
+def check_orphaned_merge(store: BeadStore) -> list[Anomaly]:
+    """Detect merge_ready beads absent from the MergeQueue."""
+    anomalies: list[Anomaly] = []
+    merge_ready_beads = store.list_work_beads(state="merge_ready")
+    if not merge_ready_beads:
+        return anomalies
+
+    queue = store.read_merge_queue()
+    queued_issues = {e.issue_number for e in queue.queue}
+
+    for bead in merge_ready_beads:
+        if bead.issue_number not in queued_issues:
+            anomalies.append(
+                Anomaly(
+                    kind="orphaned_merge",
+                    severity="warning",
+                    description=(
+                        f"Issue #{bead.issue_number} is merge_ready but absent from MergeQueue"
+                    ),
+                    details={"issue_number": bead.issue_number, "branch": bead.branch},
+                )
+            )
+
+    return anomalies
+
+
+def check_pre_pr_zombies(
+    store: BeadStore, timeout_minutes: float = ZOMBIE_TIMEOUT_MINUTES
+) -> list[Anomaly]:
+    """Detect claimed beads older than timeout with no associated PRBead."""
+    anomalies: list[Anomaly] = []
+    claimed_beads = store.list_work_beads(state="claimed")
+    now = datetime.now(UTC)
+
+    for bead in claimed_beads:
+        if bead.pr_id is not None:
+            continue  # has a PR, not a zombie
+
+        if bead.claimed_at is None:
+            continue  # no claim timestamp; can't determine age
+
+        try:
+            claimed_dt = datetime.fromisoformat(bead.claimed_at)
+        except ValueError:
+            continue
+
+        age_minutes = (now - claimed_dt).total_seconds() / 60
+        if age_minutes >= timeout_minutes:
+            anomalies.append(
+                Anomaly(
+                    kind="pre_pr_zombie",
+                    severity="warning",
+                    description=(
+                        f"Issue #{bead.issue_number} claimed {age_minutes:.0f}m ago "
+                        f"with no PR (branch: {bead.branch!r})"
+                    ),
+                    details={
+                        "issue_number": bead.issue_number,
+                        "branch": bead.branch,
+                        "claimed_at": bead.claimed_at,
+                        "age_minutes": round(age_minutes, 1),
+                    },
+                )
+            )
+
+    return anomalies
+
+
+# ---------------------------------------------------------------------------
+# All detectors
+# ---------------------------------------------------------------------------
+
+_DETECTORS = [
+    ("label_drift", lambda store, repo: check_label_drift(store, repo)),
+    ("dep_integrity", lambda store, repo: check_dep_integrity(store)),
+    ("state_regressions", lambda store, repo: check_state_regressions(store)),
+    ("orphaned_merge", lambda store, repo: check_orphaned_merge(store)),
+    ("pre_pr_zombies", lambda store, repo: check_pre_pr_zombies(store)),
+]
+
+
+def run_all_detectors(store: BeadStore, repo: str) -> list[Anomaly]:
+    """Run every detector and return the combined list of anomalies."""
+    anomalies: list[Anomaly] = []
+    for name, detector in _DETECTORS:
+        try:
+            found = detector(store, repo)
+            anomalies.extend(found)
+        except Exception as exc:  # noqa: BLE001
+            # Never let a detector crash the monitor loop
+            anomalies.append(
+                Anomaly(
+                    kind="detector_error",
+                    severity="warning",
+                    description=f"Detector {name!r} raised an exception: {exc}",
+                    details={"detector": name, "error": str(exc)},
+                )
+            )
+    return anomalies
+
+
+# ---------------------------------------------------------------------------
+# Dedup / filing
+# ---------------------------------------------------------------------------
+
+
+def _load_filed(beads_dir: Path) -> dict[str, str]:
+    """Load the monitor-filed.json dedup map {fingerprint: issue_url}."""
+    path = beads_dir / MONITOR_FILED_FILENAME
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_filed(beads_dir: Path, filed: dict[str, str]) -> None:
+    """Atomically write the monitor-filed.json dedup map."""
+    path = beads_dir / MONITOR_FILED_FILENAME
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(filed, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _build_issue_body(anomaly: Anomaly) -> str:
+    details_block = json.dumps(anomaly.details, indent=2)
+    return (
+        f"## Monitor Anomaly: `{anomaly.kind}`\n\n"
+        f"**Severity:** {anomaly.severity}\n\n"
+        f"**Description:** {anomaly.description}\n\n"
+        f"## Details\n"
+        f"```json\n{details_block}\n```\n\n"
+        f"*Filed automatically by `brimstone monitor`.*"
+    )
+
+
+def file_anomaly_issue(anomaly: Anomaly, repo: str) -> str | None:
+    """File a GitHub issue for the anomaly. Returns the issue URL or None on failure."""
+    label = "bug,P1" if anomaly.severity == "critical" else "bug,P2"
+    title = f"[monitor] {anomaly.kind}: {anomaly.description[:80]}"
+    body = _build_issue_body(anomaly)
+
+    result = _gh(
+        ["issue", "create", "--title", title, "--label", label, "--body", body],
+        repo=repo,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    # gh issue create prints the URL on stdout
+    url = result.stdout.strip()
+    return url if url else None
+
+
+def process_anomalies(
+    anomalies: list[Anomaly],
+    store: BeadStore,
+    repo: str,
+    dry_run: bool = False,
+) -> list[str]:
+    """Dedup and file GitHub issues for each new anomaly.
+
+    Returns a list of URLs for issues filed this run.
+    """
+    beads_dir = store._beads_dir
+    filed = _load_filed(beads_dir)
+    new_urls: list[str] = []
+
+    for anomaly in anomalies:
+        fp = anomaly.fingerprint()
+        if fp in filed:
+            continue  # already filed
+
+        if dry_run:
+            desc = anomaly.description
+            print(f"[monitor/dry-run] {anomaly.severity.upper()} {anomaly.kind}: {desc}")
+            filed[fp] = "dry-run"
+            continue
+
+        url = file_anomaly_issue(anomaly, repo)
+        if url:
+            filed[fp] = url
+            new_urls.append(url)
+            print(f"[monitor] filed {anomaly.severity} issue: {url}")
+        else:
+            print(f"[monitor] WARN: failed to file issue for {anomaly.kind!r}")
+
+    if not dry_run:
+        _save_filed(beads_dir, filed)
+    return new_urls
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def run_monitor(
+    store: BeadStore,
+    repo: str,
+    *,
+    once: bool = False,
+    interval: int = MONITOR_INTERVAL_SECONDS,
+    dry_run: bool = False,
+) -> None:
+    """Run the monitoring loop.
+
+    Args:
+        store:    BeadStore for the target repo.
+        repo:     ``owner/repo`` string (for GitHub API calls).
+        once:     If True, run one pass and return instead of looping.
+        interval: Seconds between detection passes.
+        dry_run:  If True, print anomalies but do not file GitHub issues.
+    """
+    print(f"[monitor] starting for {repo} (interval={interval}s, once={once})")
+
+    while True:
+        ts = datetime.now(UTC).isoformat()
+        print(f"[monitor] scan at {ts}")
+
+        anomalies = run_all_detectors(store, repo)
+
+        if anomalies:
+            new_urls = process_anomalies(anomalies, store, repo, dry_run=dry_run)
+            total = len(anomalies)
+            new = len(new_urls)
+            print(f"[monitor] {total} anomaly/ies found, {new} new issue(s) filed")
+        else:
+            print("[monitor] clean — no anomalies")
+
+        if once:
+            break
+
+        time.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _gh(
+    args: list[str], *, repo: str | None = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    """Thin wrapper around ``gh`` CLI."""
+    cmd = ["gh"]
+    if repo:
+        cmd += ["--repo", repo]
+    cmd += args
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)

--- a/src/brimstone/skills/design-worker-hld.md
+++ b/src/brimstone/skills/design-worker-hld.md
@@ -41,9 +41,37 @@ cat docs/specs/*.md
 cat CLAUDE.md 2>/dev/null || true
 ```
 
+### Step 1.5 — Read the Previous HLD (skip only for the very first milestone)
+
+```bash
+# List all existing design milestones in sorted order
+ls docs/design/ 2>/dev/null | sort -V
+
+# Read the most recent prior HLD
+cat docs/design/<previous-milestone>/HLD.md 2>/dev/null \
+  || echo "No prior HLD found — this is the first milestone."
+```
+
+You will integrate the prior HLD in Step 2.
+
 ### Step 2 — Write the HLD
 
 Create `docs/design/<milestone>/HLD.md` in the local checkout.
+
+**The HLD is a complete system snapshot, never a delta.**
+
+- **First milestone only** (no prior HLD exists): write from scratch using the sections below.
+- **All subsequent milestones**: read the previous HLD (Step 1.5), then produce a
+  **complete system snapshot** for the current version. Pull forward all retained
+  architecture, design decisions, module descriptions, cross-cutting concerns, and
+  data flow from the previous HLD. Integrate the new additions throughout.
+  A reader must be able to understand the entire current system from this document
+  alone — without consulting any prior version.
+
+**Common mistakes to avoid:**
+- Do NOT write "v0.2.0 adds X and Y" and stop — describe the full system at this version.
+- Do NOT omit foundational design decisions from earlier milestones; carry them forward.
+- Do NOT write the System Overview as a list of changes from the last version; describe the system as it exists now.
 
 The HLD must cover:
 

--- a/src/brimstone/skills/design-worker-lld.md
+++ b/src/brimstone/skills/design-worker-lld.md
@@ -64,6 +64,29 @@ ls docs/design/ && cat docs/design/*/lld/<module>.md 2>/dev/null || true
 
 Create `docs/design/<milestone>/lld/<module>.md` in your working directory.
 
+**The LLD is a delta document, never a full system description.**
+
+Before writing, determine your change scope by comparing the current requirements
+against the previous-milestone LLD you read in Step 2:
+
+- **No code changes in this module:** Write a minimal doc. State that the module is
+  unchanged, explain in one paragraph why the existing code already handles this
+  version's new requirements (e.g. "the `except CalcError` handler catches all new
+  subclasses by inheritance"), and list only the new test cases added. Omit all
+  sections about data structures, algorithms, and interfaces — refer the reader to
+  the previous LLD for those. This is the correct, complete LLD for a no-change module.
+- **Partial changes:** Write only the sections that changed. For sections that are
+  identical to the prior version (e.g. TokenType variants that didn't change), omit
+  them or write "Unchanged from v0.X.0 — see `docs/design/v0.X.0/lld/<module>.md`."
+  Lead each changed section with what is new or different.
+- **Significant rewrite or new module:** Write all sections as normal, but explicitly
+  call out which parts are new vs. inherited from prior milestones.
+
+**Common mistakes to avoid:**
+- Do NOT copy-paste the full prior LLD and add a few lines at the bottom.
+- Do NOT repeat unchanged interfaces, data structures, or algorithms.
+- Do NOT write the LLD as if the prior version didn't exist.
+
 The LLD must cover:
 
 **Overview**

--- a/src/brimstone/skills/scope-worker.md
+++ b/src/brimstone/skills/scope-worker.md
@@ -70,17 +70,39 @@ gh issue list --state closed --milestone "<milestone>" --label "stage/impl" --li
   --json number,title,labels --repo <owner>/<repo>
 ```
 
-Build a set of normalized titles to skip during Step 3.
+Build **two** skip sets from all returned issues (open + closed):
 
-### Step 3 — File Scaffold Issue First
+1. **Normalized titles** — lowercase the title, strip all punctuation and the milestone
+   suffix (e.g. `" (v0.3.0)"`), collapse whitespace. If a proposed title normalizes to
+   the same string as an existing issue, skip it.
 
-Before planning any module-level impl issues, always file a project scaffold issue that
-covers shared project-wide files. This **must** be filed as the very first issue and all
-other impl issues must depend on it.
+2. **Covered modules** — extract the module name from each existing issue title.
+   Any word that matches a module name from the LLD list (e.g. `lexer`, `parser`,
+   `evaluator`, `errors`, `cli`) counts as "covered".
+   If the module you are about to file an issue for is already covered by any existing
+   `stage/impl` issue (regardless of title format), **skip it entirely**.
+
+A proposed issue is skipped if **either** condition matches.
+This prevents duplicate module issues even when title phrasing differs between runs.
+
+### Step 3 — File Scaffold Issue First (initial milestone only)
+
+**First, check whether the project is already bootstrapped:**
+```bash
+gh api repos/<owner>/<repo>/contents/pyproject.toml 2>/dev/null && echo EXISTS || echo MISSING
+```
+
+If `pyproject.toml` **already exists** on the default branch, the project is already
+scaffolded from a prior milestone. **Skip this entire step** — do not file a scaffold
+issue, do not create scaffold dependencies. Proceed directly to Step 3b.
+
+If `pyproject.toml` is **missing**, file a scaffold issue as the very first issue.
+All other impl issues must depend on it.
 
 **Why:** Impl workers run in parallel. If each worker independently creates `pyproject.toml`
 or `src/<pkg>/__init__.py`, every PR will have merge conflicts. The scaffold issue claims
-these shared files so parallel workers never touch them.
+these shared files so parallel workers never touch them. On subsequent milestones the
+scaffold already exists — filing it again wastes an agent run and produces a no-op PR.
 
 File the scaffold issue:
 ```bash
@@ -124,8 +146,11 @@ EOF
 )"
 ```
 
-Record the scaffold issue number. **Every other impl issue filed in Step 3 must include
+Record the scaffold issue number. **Every other impl issue filed in Step 3b must include
 `Depends on: #<scaffold-issue>` in its body.**
+
+If Step 3 was skipped (project already bootstrapped), do **not** add scaffold dependencies
+to any issue — there is no scaffold issue for this milestone.
 
 ### Step 3b — Plan Module Implementation Issues
 
@@ -135,19 +160,17 @@ For each logical unit of work needed to implement what the design docs specify:
    Each issue must be scoped to exactly one module from the module isolation table.
    One issue per logical unit per module.
 
-2. **Write acceptance criteria** — concrete, testable, binary conditions for "done".
-   Use "must" language only; avoid "should" and "might".
-   At least two criteria per issue.
+2. **Write acceptance criteria** — 2–4 binary, observable conditions for "done".
+   These describe external behaviour changes, not implementation steps.
+   Do NOT copy test cases, diffs, or function signatures from the LLD.
 
-3. **Write test requirements** — what unit tests must exist, what integration tests (if any).
-   Reference specific function or class names where the design doc names them.
-
-4. **Identify dependencies** — which other impl issues (by title or anticipated number)
+3. **Identify dependencies** — which other impl issues (by title or anticipated number)
    must complete before this one can start?
-   **Every module issue must depend on the scaffold issue filed in Step 3 at minimum.**
+   **If a scaffold issue was filed in Step 3, every module issue must depend on it.**
+   If Step 3 was skipped (project already bootstrapped), do not add scaffold dependencies.
    Check for circular dependencies before proceeding.
 
-5. **Assign label** — use the appropriate `feat:*` label from CLAUDE.md:
+4. **Assign label** — use the appropriate `feat:*` label from CLAUDE.md:
    - `feat:config` — `src/brimstone/config.py`
    - `feat:runner` — `src/brimstone/runner.py`, `src/brimstone/session.py`
    - `feat:health` — `src/brimstone/health.py`
@@ -155,8 +178,11 @@ For each logical unit of work needed to implement what the design docs specify:
    - `feat:cli` — `src/brimstone/cli.py`, `src/brimstone/skills/`
    - `infra` — `pyproject.toml`, `.github/`, `CLAUDE.md`, `README.md`
 
-6. **Skip if duplicate** — if a normalized version of the proposed title matches an existing
-   issue title, log the skip and move on.
+5. **Skip if duplicate** — skip the issue if ANY of the following is true:
+   - A normalized version of the proposed title matches an existing issue title.
+   - The module this issue targets is already covered by any existing `stage/impl`
+     issue for this milestone (check the "covered modules" set from Step 2).
+   Log the skip reason and move on. **Never file two issues for the same module.**
 
 If `--dry-run` is set, print each planned issue (title, label, scope, criteria summary, deps)
 to stdout and STOP — do not call `gh issue create`.
@@ -165,35 +191,30 @@ Otherwise, file each issue:
 ```bash
 gh issue create \
   --repo <owner>/<repo> \
-  --title "<imperative verb phrase>" \
+  --title "impl: <module> — <one-line summary of what changes>" \
   --label "<feat:*>,stage/impl,P2" \
   --milestone "<milestone>" \
   --body "$(cat <<'EOF'
-## Context
-<1-2 sentences: what design doc section this implements and why it is needed>
+## Module
+`<module>` — `<primary file(s)>`
+
+## LLD Reference
+`docs/design/<milestone>/lld/<module>.md`
+The impl agent must read this document in full before writing any code.
 
 ## Acceptance Criteria
-- [ ] <concrete, testable criterion 1>
-- [ ] <concrete, testable criterion 2>
-- [ ] ...
-
-## Scope
-Files to create or modify:
-- `<path>` — <what changes>
-
-## Test Requirements
-- <what must be unit-tested>
-- <what must be integration-tested (if any)>
+- [ ] <binary, testable criterion — what "done" looks like from the outside>
+- [ ] <one criterion per observable behaviour change; 2–4 total>
+- [ ] All existing tests pass; new tests added per the LLD test strategy
 
 ## Dependencies
 <Depends on: #N, or "None">
-
-## Key Design Decisions
-<Bullet list of non-obvious decisions made by the design docs, so the impl agent
-does not re-litigate them. Reference the relevant LLD section if helpful.>
 EOF
 )"
 ```
+
+**Do not include** diffs, code snippets, test cases, or step-by-step implementation notes.
+The impl agent reads the LLD directly — the issue body is routing metadata, not a spec.
 
 Record each filed issue number for the dependency step.
 

--- a/tests/unit/test_cli_design.py
+++ b/tests/unit/test_cli_design.py
@@ -366,12 +366,11 @@ class TestDesignWorkerPhase1:
             patch(_DESIGN_PATCHES["log_event"]),
             patch(_DESIGN_PATCHES["save_session"]),
             patch(_DESIGN_PATCHES["slugify"], return_value="design-hld-v1"),
-            # Gate 1 calls _list_open_issues_by_label for research before _classify_blocking_issues
+            # Phase 1 calls _list_open_issues_by_label once after _file_design_issue_if_missing
             patch(
                 "brimstone.cli._list_open_issues_by_label",
                 side_effect=[
-                    [],  # Gate 1: research check (classify_blocking patched → ([], []))
-                    [hld_issue],  # Phase 1: finding HLD issue
+                    [hld_issue],  # Phase 1: finding HLD issue after create
                     [lld_issue],  # Phase 2: finding LLD issues
                 ],
             ),

--- a/tests/unit/test_cli_impl.py
+++ b/tests/unit/test_cli_impl.py
@@ -2203,6 +2203,8 @@ class TestEndOfRunCostSummary:
         object.__setattr__(config, "log_dir", log_dir)
         checkpoint = make_checkpoint()
 
+        mock_store = MagicMock()
+        mock_store.list_work_beads.return_value = [MagicMock()]  # non-empty → gate passes
         with patch.dict("os.environ", MINIMAL_ENV, clear=False):
             with (
                 patch("brimstone.cli._resolve_repo", return_value=_REPO),
@@ -2213,6 +2215,7 @@ class TestEndOfRunCostSummary:
                 ),
                 patch("brimstone.cli._count_open_issues_by_label", return_value=2),
                 patch("brimstone.cli._ensure_labels"),
+                patch("brimstone.cli.make_bead_store", return_value=mock_store),
                 patch(
                     "brimstone.cli.startup_sequence",
                     return_value=(config, checkpoint, MagicMock()),

--- a/tests/unit/test_cli_research.py
+++ b/tests/unit/test_cli_research.py
@@ -903,8 +903,8 @@ class TestRunResearchWorkerRateLimit:
 
 
 class TestRunResearchWorkerErrorHandling:
-    def test_escalates_after_max_retries(self, tmp_path: Path) -> None:
-        """After MAX_RETRIES failures, a human_escalate event is logged."""
+    def test_nuclear_restart_after_max_retries(self, tmp_path: Path) -> None:
+        """After MAX_RETRIES failures, agent_nuclear_restart is logged (not human_escalate)."""
         config = make_config()
         object.__setattr__(config, "checkpoint_dir", tmp_path)
         object.__setattr__(config, "log_dir", tmp_path / "logs")
@@ -916,7 +916,7 @@ class TestRunResearchWorkerErrorHandling:
         dispatch_calls = {"count": 0}
 
         def open_issues_side_effect(repo, milestone, label):
-            # Return the issue enough times to exhaust retries, then stop
+            # Return the issue enough times to trigger one restart cycle, then stop
             dispatch_calls["count"] += 1
             if dispatch_calls["count"] <= 4:
                 return [blocking_issue]
@@ -946,6 +946,7 @@ class TestRunResearchWorkerErrorHandling:
             patch("brimstone.cli._unclaim_issue"),
             patch("brimstone.cli._create_worktree", return_value="/tmp/fake-worktree"),
             patch("brimstone.cli._remove_worktree"),
+            patch("brimstone.cli._delete_remote_branch"),
             patch("brimstone.cli.runner.run", return_value=error_result),
             patch("brimstone.cli._run_completion_gate"),
             patch("brimstone.cli.build_subprocess_env", return_value={}),
@@ -959,6 +960,68 @@ class TestRunResearchWorkerErrorHandling:
                 checkpoint=checkpoint,
             )
 
+        assert "agent_nuclear_restart" in logged_events
+        assert "human_escalate" not in logged_events
+
+    def test_escalates_after_max_retries(self, tmp_path: Path) -> None:
+        """After 2 nuclear restarts + final MAX_RETRIES failures, human_escalate is logged."""
+        config = make_config()
+        object.__setattr__(config, "checkpoint_dir", tmp_path)
+        object.__setattr__(config, "log_dir", tmp_path / "logs")
+        checkpoint = make_checkpoint()
+
+        blocking_issue = make_issue(1, body="[BLOCKS_IMPL]")
+        error_result = make_run_result(is_error=True, subtype="error_during_execution")
+
+        dispatch_calls = {"count": 0}
+
+        def open_issues_side_effect(repo, milestone, label):
+            # Return the issue enough times to exhaust 2 restarts (3 × MAX_RETRIES = 9), then stop
+            dispatch_calls["count"] += 1
+            if dispatch_calls["count"] <= 12:
+                return [blocking_issue]
+            return []
+
+        classify_calls = {"count": 0}
+
+        def classify_side_effect(
+            open_issues, repo, milestone, config, checkpoint, dry_run=False, store=None
+        ):
+            classify_calls["count"] += 1
+            if classify_calls["count"] <= 12:
+                return ([blocking_issue], [])
+            return ([], [])
+
+        logged_events: list[str] = []
+
+        def capture_event(**kwargs):
+            logged_events.append(kwargs.get("event_type", ""))
+
+        with (
+            patch("brimstone.cli._list_open_issues_by_label", side_effect=open_issues_side_effect),
+            patch("brimstone.cli._classify_blocking_issues", side_effect=classify_side_effect),
+            patch("brimstone.cli._filter_unblocked", return_value=[blocking_issue]),
+            patch("brimstone.cli._sort_issues", return_value=[blocking_issue]),
+            patch("brimstone.cli._claim_issue"),
+            patch("brimstone.cli._unclaim_issue"),
+            patch("brimstone.cli._create_worktree", return_value="/tmp/fake-worktree"),
+            patch("brimstone.cli._remove_worktree"),
+            patch("brimstone.cli._delete_remote_branch"),
+            patch("brimstone.cli._exhaust_issue"),
+            patch("brimstone.cli.runner.run", return_value=error_result),
+            patch("brimstone.cli._run_completion_gate"),
+            patch("brimstone.cli.build_subprocess_env", return_value={}),
+            patch("brimstone.cli.logger.log_conductor_event", side_effect=capture_event),
+            patch("brimstone.cli.session.save"),
+        ):
+            _run_research_worker(
+                repo="owner/repo",
+                milestone="MVP Research",
+                config=config,
+                checkpoint=checkpoint,
+            )
+
+        assert "agent_nuclear_restart" in logged_events
         assert "human_escalate" in logged_events
 
     def test_unclaims_issue_on_error(self, tmp_path: Path) -> None:

--- a/tests/unit/test_cli_run.py
+++ b/tests/unit/test_cli_run.py
@@ -283,6 +283,7 @@ class TestRunGates:
             return [MagicMock(state="open")] if kw.get("stage") == "impl" else []
 
         mock_store.list_work_beads.side_effect = _beads
+        mock_store.scope_needs_rerun.return_value = False  # scope already complete
 
         with patch.dict("os.environ", MINIMAL_ENV, clear=False):
             with (
@@ -418,6 +419,8 @@ class TestRunScopeStage:
 
     def test_impl_runs_when_impl_issues_exist(self, tmp_path: Path) -> None:
         calls: list[str] = []
+        mock_store = MagicMock()
+        mock_store.list_work_beads.return_value = [MagicMock()]  # impl bead exists → gate passes
 
         with patch.dict("os.environ", MINIMAL_ENV, clear=False):
             with (
@@ -425,7 +428,7 @@ class TestRunScopeStage:
                 patch("brimstone.cli._milestone_exists", return_value=True),
                 patch("brimstone.cli._get_default_branch_for_repo", return_value="main"),
                 patch("brimstone.cli._doc_exists_on_default_branch", return_value=True),
-                patch("brimstone.cli._count_open_issues_by_label", return_value=2),
+                patch("brimstone.cli.make_bead_store", return_value=mock_store),
                 patch(
                     "brimstone.cli.startup_sequence",
                     return_value=(object(), object(), object()),
@@ -552,13 +555,15 @@ class TestStageFlag:
     def test_stage_impl_invokes_impl_worker(self, tmp_path: Path) -> None:
         """--stage impl must invoke _run_impl_worker."""
         calls: list[str] = []
+        mock_store = MagicMock()
+        mock_store.list_work_beads.return_value = [MagicMock()]  # impl bead exists → gate passes
 
         with patch.dict("os.environ", MINIMAL_ENV, clear=False):
             with (
                 patch("brimstone.cli._resolve_repo", return_value=_REPO),
                 patch("brimstone.cli._milestone_exists", return_value=True),
                 patch("brimstone.cli._get_default_branch_for_repo", return_value="main"),
-                patch("brimstone.cli._count_open_issues_by_label", return_value=2),
+                patch("brimstone.cli.make_bead_store", return_value=mock_store),
                 patch(
                     "brimstone.cli.startup_sequence",
                     return_value=(object(), object(), object()),
@@ -651,13 +656,15 @@ class TestStageFlag:
     def test_legacy_impl_flag_still_works(self, tmp_path: Path) -> None:
         """The deprecated --impl flag must still work as before."""
         calls: list[str] = []
+        mock_store = MagicMock()
+        mock_store.list_work_beads.return_value = [MagicMock()]  # impl bead exists → gate passes
 
         with patch.dict("os.environ", MINIMAL_ENV, clear=False):
             with (
                 patch("brimstone.cli._resolve_repo", return_value=_REPO),
                 patch("brimstone.cli._milestone_exists", return_value=True),
                 patch("brimstone.cli._get_default_branch_for_repo", return_value="main"),
-                patch("brimstone.cli._count_open_issues_by_label", return_value=2),
+                patch("brimstone.cli.make_bead_store", return_value=mock_store),
                 patch(
                     "brimstone.cli.startup_sequence",
                     return_value=(object(), object(), object()),
@@ -817,6 +824,10 @@ class TestCampaignLoop:
                     return 0  # campaign gate: impl is done, advance
             return 3  # completion check: issue exists, run the stage
 
+        # Store returned by startup_sequence — list_work_beads=[] exits campaign polling loop.
+        startup_seq_store = MagicMock()
+        startup_seq_store.list_work_beads.return_value = []
+
         with patch.dict("os.environ", MINIMAL_ENV, clear=False):
             with (
                 patch("brimstone.cli._resolve_repo", return_value=_REPO),
@@ -834,7 +845,7 @@ class TestCampaignLoop:
                 patch("brimstone.cli.make_bead_store") as mock_make_store,
                 patch(
                     "brimstone.cli.startup_sequence",
-                    return_value=(object(), object(), object()),
+                    return_value=(object(), object(), startup_seq_store),
                 ),
                 patch("brimstone.cli._run_plan", side_effect=fake_plan),
                 patch("brimstone.cli._run_research_worker", side_effect=fake_research),
@@ -842,10 +853,11 @@ class TestCampaignLoop:
                 patch("brimstone.cli._run_plan_issues", side_effect=fake_scope),
                 patch("brimstone.cli._run_impl_worker", side_effect=fake_impl),
             ):
-                # Mock the campaign bead store
+                # Mock the campaign bead store (used for CampaignBead r/w via make_bead_store).
                 mock_store = MagicMock()
                 mock_store.read_campaign_bead.return_value = None
                 mock_store.write_campaign_bead = MagicMock()
+                mock_store.list_work_beads.return_value = []
                 mock_make_store.return_value = mock_store
 
                 runner = CliRunner()

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -590,80 +590,90 @@ def test_check_worktrees_warn_when_removal_fails(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_check_orphaned_issues_pass_no_issues(tmp_path: Path) -> None:
-    """Returns pass when no in-progress issues."""
-    config = make_config(tmp_path)
-    with patch("subprocess.run", return_value=_subprocess_result(returncode=0, stdout="[]")):
-        result = _check_orphaned_issues(config)
+def test_check_orphaned_issues_pass_no_github_repo(tmp_path: Path) -> None:
+    """Returns pass (skipped) when no github_repo is configured."""
+    config = make_config(tmp_path)  # no github_repo
+    result = _check_orphaned_issues(config)
     assert result.status == "pass"
+    assert "skipped" in result.message
 
 
-def test_check_orphaned_issues_pass_all_have_prs(tmp_path: Path) -> None:
-    """Returns pass when all in-progress issues have open PRs."""
-    config = make_config(tmp_path)
-    issues = json.dumps([{"number": 10, "title": "feat: thing"}])
-    prs = json.dumps([{"number": 42, "headRefName": "10-feat-thing"}])
+def test_check_orphaned_issues_pass_no_claimed_beads(tmp_path: Path) -> None:
+    """Returns pass when bead store has no claimed beads."""
+    from brimstone.beads import make_bead_store
 
-    call_count = 0
+    config = make_config(tmp_path, github_repo="owner/repo", beads_dir=tmp_path / "beads")
+    store = make_bead_store(config, "owner/repo")
+    # Write an open (not claimed) bead to confirm it isn't counted
+    from brimstone.beads import WorkBead
 
-    def side_effect(cmd, **kwargs):  # noqa: ANN001
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return _subprocess_result(returncode=0, stdout=issues)
-        return _subprocess_result(returncode=0, stdout=prs)
-
-    with patch("subprocess.run", side_effect=side_effect):
-        result = _check_orphaned_issues(config)
-    assert result.status == "pass"
-
-
-def test_check_orphaned_issues_warn_below_threshold(tmp_path: Path) -> None:
-    """Returns warn when orphaned count is at or below max_orphaned_issues."""
-    config = make_config(tmp_path, max_orphaned_issues=5)
-    issues = json.dumps([{"number": 10, "title": "feat: thing"}])
-    prs = json.dumps([])  # No open PRs → orphaned
-
-    call_count = 0
-
-    def side_effect(cmd, **kwargs):  # noqa: ANN001
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return _subprocess_result(returncode=0, stdout=issues)
-        return _subprocess_result(returncode=0, stdout=prs)
-
-    with patch("subprocess.run", side_effect=side_effect):
-        result = _check_orphaned_issues(config)
-    assert result.status == "warn"
-    assert result.remediation is not None
-
-
-def test_check_orphaned_issues_fail_above_threshold(tmp_path: Path) -> None:
-    """Returns fail when orphaned count exceeds max_orphaned_issues."""
-    config = make_config(tmp_path, max_orphaned_issues=2)
-    issues = json.dumps(
-        [
-            {"number": 10, "title": "one"},
-            {"number": 11, "title": "two"},
-            {"number": 12, "title": "three"},
-        ]
+    store.write_work_bead(
+        WorkBead(
+            v=1,
+            issue_number=1,
+            title="open issue",
+            milestone="v1",
+            stage="impl",
+            module="config",
+            priority="P2",
+            state="open",
+            branch="1-open-issue",
+        )
     )
-    prs = json.dumps([])
+    result = _check_orphaned_issues(config)
+    assert result.status == "pass"
 
-    call_count = 0
 
-    def side_effect(cmd, **kwargs):  # noqa: ANN001
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return _subprocess_result(returncode=0, stdout=issues)
-        return _subprocess_result(returncode=0, stdout=prs)
+def test_check_orphaned_issues_pass_all_have_pr_beads(tmp_path: Path) -> None:
+    """Returns pass when all claimed beads have active PR beads."""
+    from brimstone.beads import PRBead, WorkBead, make_bead_store
 
-    with patch("subprocess.run", side_effect=side_effect):
-        result = _check_orphaned_issues(config)
-    assert result.status == "fail"
-    assert "3 >" in (result.message + (result.remediation or ""))
+    config = make_config(tmp_path, github_repo="owner/repo", beads_dir=tmp_path / "beads")
+    store = make_bead_store(config, "owner/repo")
+    store.write_work_bead(
+        WorkBead(
+            v=1,
+            issue_number=10,
+            title="feat: thing",
+            milestone="v1",
+            stage="impl",
+            module="config",
+            priority="P2",
+            state="claimed",
+            branch="10-feat-thing",
+        )
+    )
+    store.write_pr_bead(
+        PRBead(v=1, pr_number=42, issue_number=10, branch="10-feat-thing", state="open")
+    )
+    result = _check_orphaned_issues(config)
+    assert result.status == "pass"
+
+
+def test_check_orphaned_issues_warn_no_pr_bead(tmp_path: Path) -> None:
+    """Returns warn when a claimed bead has no active PR bead."""
+    from brimstone.beads import WorkBead, make_bead_store
+
+    config = make_config(tmp_path, github_repo="owner/repo", beads_dir=tmp_path / "beads")
+    store = make_bead_store(config, "owner/repo")
+    store.write_work_bead(
+        WorkBead(
+            v=1,
+            issue_number=10,
+            title="feat: thing",
+            milestone="v1",
+            stage="impl",
+            module="config",
+            priority="P2",
+            state="claimed",
+            branch="10-feat-thing",
+        )
+    )
+    # No PR bead written → orphaned
+    result = _check_orphaned_issues(config)
+    assert result.status == "warn"
+    assert "#10" in result.message
+    assert result.remediation is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -670,8 +670,8 @@ def test_log_conductor_event_appends_multiple_events(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_conductor_event_types_contains_all_16() -> None:
-    """BRIMSTONE_EVENT_TYPES contains exactly the 16 documented event types."""
+def test_conductor_event_types_contains_all_17() -> None:
+    """BRIMSTONE_EVENT_TYPES contains exactly the 17 documented event types."""
     expected = {
         "stage_start",
         "issue_claimed",
@@ -690,5 +690,6 @@ def test_conductor_event_types_contains_all_16() -> None:
         "agent_nuclear_restart",
         "agent_exception",
         "recovery_dispatched",
+        "dependency_pruned",
     }
     assert BRIMSTONE_EVENT_TYPES == expected

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -670,8 +670,8 @@ def test_log_conductor_event_appends_multiple_events(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_conductor_event_types_contains_all_11() -> None:
-    """BRIMSTONE_EVENT_TYPES contains exactly the 11 documented event types."""
+def test_conductor_event_types_contains_all_16() -> None:
+    """BRIMSTONE_EVENT_TYPES contains exactly the 16 documented event types."""
     expected = {
         "stage_start",
         "issue_claimed",
@@ -685,5 +685,10 @@ def test_conductor_event_types_contains_all_11() -> None:
         "human_escalate",
         "checkpoint_write",
         "stage_complete",
+        "inline_comments_present",
+        "ci_monitoring_complete_no_merge",
+        "agent_nuclear_restart",
+        "agent_exception",
+        "recovery_dispatched",
     }
     assert BRIMSTONE_EVENT_TYPES == expected

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -9,18 +9,27 @@ from unittest.mock import MagicMock, patch
 
 from brimstone.beads import (
     BEAD_SCHEMA_VERSION,
+    AnomalyBead,
     BeadStore,
     MergeQueue,
     MergeQueueEntry,
     WorkBead,
 )
 from brimstone.monitor import (
+    INLINE_REPAIR_MAX_ATTEMPTS,
     Anomaly,
+    _anomaly_id,
+    _apply_inline_repair,
+    _get_active_milestone,
+    _inline_repair_label_drift,
+    _inline_repair_orphaned_merge,
     check_dep_integrity,
     check_label_drift,
     check_orphaned_merge,
     check_pre_pr_zombies,
     check_state_regressions,
+    classify_blocking,
+    classify_repair_tier,
     process_anomalies,
     run_all_detectors,
 )
@@ -60,6 +69,13 @@ def _make_store(tmp_path: Path) -> BeadStore:
     return BeadStore(tmp_path)
 
 
+def _make_gh_result(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    r = MagicMock(spec=subprocess.CompletedProcess)
+    r.stdout = stdout
+    r.returncode = returncode
+    return r
+
+
 # ---------------------------------------------------------------------------
 # Anomaly.fingerprint
 # ---------------------------------------------------------------------------
@@ -88,19 +104,149 @@ def test_anomaly_fingerprint_differs_by_details():
 
 
 # ---------------------------------------------------------------------------
+# _anomaly_id
+# ---------------------------------------------------------------------------
+
+
+def test_anomaly_id_stable():
+    a = Anomaly(kind="label_drift", severity="warning", description="x", details={"n": 1})
+    assert _anomaly_id(a) == _anomaly_id(a)
+    assert len(_anomaly_id(a)) == 16
+
+
+def test_anomaly_id_differs_by_kind():
+    a = Anomaly(kind="label_drift", severity="warning", description="x", details={"n": 1})
+    b = Anomaly(kind="dep_cycle", severity="warning", description="x", details={"n": 1})
+    assert _anomaly_id(a) != _anomaly_id(b)
+
+
+# ---------------------------------------------------------------------------
+# classify_repair_tier
+# ---------------------------------------------------------------------------
+
+
+def test_classify_repair_tier_inline():
+    a = Anomaly(kind="label_drift", severity="w", description="")
+    assert classify_repair_tier(a) == "inline"
+    b = Anomaly(kind="orphaned_merge", severity="w", description="")
+    assert classify_repair_tier(b) == "inline"
+
+
+def test_classify_repair_tier_bug():
+    a = Anomaly(kind="pre_pr_zombie", severity="w", description="")
+    assert classify_repair_tier(a) == "bug"
+
+
+def test_classify_repair_tier_probe():
+    for kind in ("dep_cycle", "phantom_dep", "state_regression", "detector_error"):
+        assert classify_repair_tier(Anomaly(kind=kind, severity="c", description="")) == "probe"
+
+
+# ---------------------------------------------------------------------------
+# classify_blocking
+# ---------------------------------------------------------------------------
+
+
+def test_classify_blocking_always_blocking(tmp_path):
+    store = _make_store(tmp_path)
+    for kind in ("dep_cycle", "phantom_dep", "state_regression", "orphaned_merge"):
+        a = Anomaly(kind=kind, severity="critical", description="x")
+        assert classify_blocking(a, store, "v1.0") is True
+
+
+def test_classify_blocking_detector_error_never(tmp_path):
+    store = _make_store(tmp_path)
+    a = Anomaly(kind="detector_error", severity="warning", description="x")
+    assert classify_blocking(a, store, "v1.0") is False
+
+
+def test_classify_blocking_pre_pr_zombie_in_active_milestone(tmp_path):
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(7, state="claimed", milestone="v1.0")
+    store.write_work_bead(bead)
+    a = Anomaly(
+        kind="pre_pr_zombie",
+        severity="warning",
+        description="x",
+        details={"issue_number": 7},
+    )
+    assert classify_blocking(a, store, "v1.0") is True
+
+
+def test_classify_blocking_pre_pr_zombie_different_milestone(tmp_path):
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(7, state="claimed", milestone="v2.0")
+    store.write_work_bead(bead)
+    a = Anomaly(
+        kind="pre_pr_zombie",
+        severity="warning",
+        description="x",
+        details={"issue_number": 7},
+    )
+    assert classify_blocking(a, store, "v1.0") is False
+
+
+def test_classify_blocking_pre_pr_zombie_no_active_milestone(tmp_path):
+    store = _make_store(tmp_path)
+    a = Anomaly(
+        kind="pre_pr_zombie", severity="warning", description="x", details={"issue_number": 7}
+    )
+    assert classify_blocking(a, store, None) is False
+
+
+def test_classify_blocking_label_drift_zombie_label_on_closed(tmp_path):
+    store = _make_store(tmp_path)
+    a = Anomaly(
+        kind="label_drift",
+        severity="critical",
+        description="x",
+        details={"issue_number": 5, "bead_state": "closed", "has_label": True},
+    )
+    assert classify_blocking(a, store, "v1.0") is True
+
+
+def test_classify_blocking_label_drift_missing_label_not_blocking(tmp_path):
+    store = _make_store(tmp_path)
+    a = Anomaly(
+        kind="label_drift",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5, "bead_state": "claimed", "has_label": False},
+    )
+    assert classify_blocking(a, store, "v1.0") is False
+
+
+# ---------------------------------------------------------------------------
+# _get_active_milestone
+# ---------------------------------------------------------------------------
+
+
+def test_get_active_milestone_no_campaign(tmp_path):
+    store = _make_store(tmp_path)
+    assert _get_active_milestone(store) is None
+
+
+def test_get_active_milestone_finds_first_non_shipped(tmp_path):
+    from brimstone.beads import CampaignBead
+
+    store = _make_store(tmp_path)
+    campaign = CampaignBead(
+        v=1,
+        repo="owner/repo",
+        milestones=["v1.0", "v2.0", "v3.0"],
+        current_index=0,
+        statuses={"v1.0": "shipped", "v2.0": "implementing", "v3.0": "pending"},
+    )
+    store.write_campaign_bead(campaign)
+    assert _get_active_milestone(store) == "v2.0"
+
+
+# ---------------------------------------------------------------------------
 # check_label_drift
 # ---------------------------------------------------------------------------
 
 
-def _make_gh_result(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
-    r = MagicMock(spec=subprocess.CompletedProcess)
-    r.stdout = stdout
-    r.returncode = returncode
-    return r
-
-
 def test_check_label_drift_clean(tmp_path):
-    """No beads, no in-progress labels → no anomalies."""
     store = _make_store(tmp_path)
     with patch("brimstone.monitor._gh") as mock_gh:
         mock_gh.return_value = _make_gh_result("[]")
@@ -109,7 +255,6 @@ def test_check_label_drift_clean(tmp_path):
 
 
 def test_check_label_drift_claimed_missing_label(tmp_path):
-    """Claimed bead but no in-progress label → label_drift anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(10, state="claimed")
     store.write_work_bead(bead)
@@ -125,9 +270,7 @@ def test_check_label_drift_claimed_missing_label(tmp_path):
 
 
 def test_check_label_drift_label_no_bead(tmp_path):
-    """in-progress label on issue with no bead → label_drift anomaly."""
     store = _make_store(tmp_path)
-
     with patch("brimstone.monitor._gh") as mock_gh:
         mock_gh.return_value = _make_gh_result(json.dumps([{"number": 42}]))
         anomalies = check_label_drift(store, "owner/repo")
@@ -139,7 +282,6 @@ def test_check_label_drift_label_no_bead(tmp_path):
 
 
 def test_check_label_drift_closed_bead_with_label_is_critical(tmp_path):
-    """Closed bead with in-progress label → critical severity."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(7, state="closed")
     store.write_work_bead(bead)
@@ -153,7 +295,6 @@ def test_check_label_drift_closed_bead_with_label_is_critical(tmp_path):
 
 
 def test_check_label_drift_clean_claimed_with_label(tmp_path):
-    """Claimed bead AND in-progress label → no anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(5, state="claimed")
     store.write_work_bead(bead)
@@ -171,14 +312,12 @@ def test_check_label_drift_clean_claimed_with_label(tmp_path):
 
 
 def test_check_dep_integrity_clean(tmp_path):
-    """No deps → no anomalies."""
     store = _make_store(tmp_path)
     store.write_work_bead(_make_work_bead(1))
     assert check_dep_integrity(store) == []
 
 
 def test_check_dep_integrity_phantom_dep(tmp_path):
-    """Bead blocked_by an issue number with no bead → phantom_dep anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(2, blocked_by=[999])
     store.write_work_bead(bead)
@@ -190,7 +329,6 @@ def test_check_dep_integrity_phantom_dep(tmp_path):
 
 
 def test_check_dep_integrity_cycle(tmp_path):
-    """Two beads blocking each other → dep_cycle anomaly."""
     store = _make_store(tmp_path)
     store.write_work_bead(_make_work_bead(10, blocked_by=[11]))
     store.write_work_bead(_make_work_bead(11, blocked_by=[10]))
@@ -201,7 +339,6 @@ def test_check_dep_integrity_cycle(tmp_path):
 
 
 def test_check_dep_integrity_closed_phantom_skipped(tmp_path):
-    """Closed bead blocked_by phantom → not flagged (closed beads skip check)."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(3, state="closed", blocked_by=[999])
     store.write_work_bead(bead)
@@ -216,7 +353,6 @@ def test_check_dep_integrity_closed_phantom_skipped(tmp_path):
 
 
 def test_check_state_regressions_clean(tmp_path):
-    """Normal transitions → no anomalies."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(1)
     store.write_work_bead(bead)
@@ -229,7 +365,6 @@ def test_check_state_regressions_clean(tmp_path):
 
 
 def test_check_state_regressions_bad_transition(tmp_path):
-    """merge_ready → open transition → state_regression anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(1)
     store.write_work_bead(bead)
@@ -246,7 +381,6 @@ def test_check_state_regressions_bad_transition(tmp_path):
 
 
 def test_check_state_regressions_closed_to_open(tmp_path):
-    """closed → open → state_regression anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(2)
     store.write_work_bead(bead)
@@ -263,7 +397,6 @@ def test_check_state_regressions_closed_to_open(tmp_path):
 
 
 def test_check_orphaned_merge_clean(tmp_path):
-    """merge_ready bead in MergeQueue → no anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(5, state="merge_ready")
     store.write_work_bead(bead)
@@ -280,11 +413,9 @@ def test_check_orphaned_merge_clean(tmp_path):
 
 
 def test_check_orphaned_merge_missing_from_queue(tmp_path):
-    """merge_ready bead absent from MergeQueue → orphaned_merge anomaly."""
     store = _make_store(tmp_path)
     bead = _make_work_bead(5, state="merge_ready")
     store.write_work_bead(bead)
-    # Don't add to queue
 
     anomalies = check_orphaned_merge(store)
     assert len(anomalies) == 1
@@ -293,7 +424,6 @@ def test_check_orphaned_merge_missing_from_queue(tmp_path):
 
 
 def test_check_orphaned_merge_no_merge_ready(tmp_path):
-    """No merge_ready beads → no anomalies."""
     store = _make_store(tmp_path)
     store.write_work_bead(_make_work_bead(1, state="open"))
     assert check_orphaned_merge(store) == []
@@ -305,13 +435,11 @@ def test_check_orphaned_merge_no_merge_ready(tmp_path):
 
 
 def test_check_pre_pr_zombies_no_claimed(tmp_path):
-    """No claimed beads → no anomalies."""
     store = _make_store(tmp_path)
     assert check_pre_pr_zombies(store) == []
 
 
 def test_check_pre_pr_zombies_fresh_claimed(tmp_path):
-    """Claimed bead claimed recently → no anomaly."""
     store = _make_store(tmp_path)
     from datetime import timedelta
 
@@ -327,7 +455,6 @@ def test_check_pre_pr_zombies_fresh_claimed(tmp_path):
 
 
 def test_check_pre_pr_zombies_old_no_pr(tmp_path):
-    """Claimed bead older than timeout with no pr_id → pre_pr_zombie anomaly."""
     store = _make_store(tmp_path)
     from datetime import timedelta
 
@@ -345,7 +472,6 @@ def test_check_pre_pr_zombies_old_no_pr(tmp_path):
 
 
 def test_check_pre_pr_zombies_has_pr_skipped(tmp_path):
-    """Claimed bead with pr_id → not a zombie."""
     store = _make_store(tmp_path)
     from datetime import timedelta
 
@@ -361,51 +487,319 @@ def test_check_pre_pr_zombies_has_pr_skipped(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# process_anomalies (dedup + filing)
+# Inline repair: _inline_repair_label_drift
+# ---------------------------------------------------------------------------
+
+
+def test_inline_repair_label_drift_add_label(tmp_path):
+    """Missing label → gh issue edit --add-label called."""
+    anomaly = Anomaly(
+        kind="label_drift",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5, "bead_state": "claimed", "has_label": False},
+    )
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result("", returncode=0)
+        result = _inline_repair_label_drift(anomaly, "owner/repo")
+
+    assert result is True
+    call_args = mock_gh.call_args[0][0]
+    assert "--add-label" in call_args
+
+
+def test_inline_repair_label_drift_remove_label(tmp_path):
+    """Stale label on closed bead → gh issue edit --remove-label called."""
+    anomaly = Anomaly(
+        kind="label_drift",
+        severity="critical",
+        description="x",
+        details={"issue_number": 7, "bead_state": "closed", "has_label": True},
+    )
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result("", returncode=0)
+        result = _inline_repair_label_drift(anomaly, "owner/repo")
+
+    assert result is True
+    call_args = mock_gh.call_args[0][0]
+    assert "--remove-label" in call_args
+
+
+def test_inline_repair_label_drift_gh_failure(tmp_path):
+    anomaly = Anomaly(
+        kind="label_drift",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5, "bead_state": "claimed", "has_label": False},
+    )
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result("", returncode=1)
+        result = _inline_repair_label_drift(anomaly, "owner/repo")
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Inline repair: _inline_repair_orphaned_merge
+# ---------------------------------------------------------------------------
+
+
+def test_inline_repair_orphaned_merge_inserts_entry(tmp_path):
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(5, state="merge_ready", pr_id="pr-100")
+    store.write_work_bead(bead)
+
+    anomaly = Anomaly(
+        kind="orphaned_merge",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5, "branch": "5-branch"},
+    )
+    result = _inline_repair_orphaned_merge(anomaly, store)
+
+    assert result is True
+    queue = store.read_merge_queue()
+    assert any(e.issue_number == 5 for e in queue.queue)
+
+
+def test_inline_repair_orphaned_merge_no_bead(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="orphaned_merge",
+        severity="warning",
+        description="x",
+        details={"issue_number": 99, "branch": "99-branch"},
+    )
+    result = _inline_repair_orphaned_merge(anomaly, store)
+    assert result is False
+
+
+def test_inline_repair_orphaned_merge_already_queued(tmp_path):
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(5, state="merge_ready", pr_id="pr-100")
+    store.write_work_bead(bead)
+    queue = MergeQueue(v=BEAD_SCHEMA_VERSION)
+    queue.queue.append(
+        MergeQueueEntry(
+            pr_number=100,
+            issue_number=5,
+            branch="5-branch",
+            enqueued_at="2024-01-01T00:00:00+00:00",
+        )
+    )
+    store.write_merge_queue(queue)
+
+    anomaly = Anomaly(
+        kind="orphaned_merge",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5, "branch": "5-branch"},
+    )
+    result = _inline_repair_orphaned_merge(anomaly, store)
+    assert result is True  # idempotent — entry already present
+
+
+# ---------------------------------------------------------------------------
+# _apply_inline_repair dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_apply_inline_repair_routes_label_drift(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="label_drift",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5, "has_label": False},
+    )
+    with patch("brimstone.monitor._inline_repair_label_drift", return_value=True) as mock_fn:
+        result = _apply_inline_repair(anomaly, store, "owner/repo")
+    mock_fn.assert_called_once()
+    assert result is True
+
+
+def test_apply_inline_repair_routes_orphaned_merge(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="orphaned_merge",
+        severity="warning",
+        description="x",
+        details={"issue_number": 5},
+    )
+    with patch("brimstone.monitor._inline_repair_orphaned_merge", return_value=True) as mock_fn:
+        result = _apply_inline_repair(anomaly, store, "owner/repo")
+    mock_fn.assert_called_once()
+    assert result is True
+
+
+def test_apply_inline_repair_unknown_kind_returns_false(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(kind="dep_cycle", severity="critical", description="x")
+    result = _apply_inline_repair(anomaly, store, "owner/repo")
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# process_anomalies — new bead-based behaviour
 # ---------------------------------------------------------------------------
 
 
 def test_process_anomalies_dry_run(tmp_path, capsys):
-    """Dry-run mode prints anomalies without calling gh."""
     store = _make_store(tmp_path)
-    anomaly = Anomaly(kind="test_kind", severity="warning", description="test anomaly")
-
-    with patch("brimstone.monitor.file_anomaly_issue") as mock_file:
+    anomaly = Anomaly(
+        kind="dep_cycle",
+        severity="critical",
+        description="test anomaly",
+        details={"cycle": [1, 2]},
+    )
+    with patch("brimstone.monitor._file_repair_issue") as mock_file:
         urls = process_anomalies([anomaly], store, "owner/repo", dry_run=True)
 
     mock_file.assert_not_called()
     assert urls == []
     captured = capsys.readouterr()
-    assert "test_kind" in captured.out
+    assert "dep_cycle" in captured.out
 
 
-def test_process_anomalies_dedup(tmp_path):
-    """Same anomaly filed twice: second call is skipped."""
+def test_process_anomalies_creates_anomaly_bead(tmp_path):
     store = _make_store(tmp_path)
-    anomaly = Anomaly(kind="dup_kind", severity="warning", description="dup", details={"x": 1})
-    url = "https://github.com/issues/99"
+    anomaly = Anomaly(
+        kind="dep_cycle",
+        severity="critical",
+        description="cycle",
+        details={"cycle": [1, 2]},
+    )
+    with patch("brimstone.monitor._file_repair_issue", return_value="https://github.com/issues/1"):
+        process_anomalies([anomaly], store, "owner/repo")
 
-    with patch("brimstone.monitor.file_anomaly_issue", return_value=url) as mock_file:
+    aid = _anomaly_id(anomaly)
+    bead = store.read_anomaly_bead(aid)
+    assert bead is not None
+    assert bead.kind == "dep_cycle"
+    assert bead.repair_tier == "probe"
+    assert bead.source_repo == "owner/repo"
+
+
+def test_process_anomalies_dedup_by_anomaly_bead(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="dep_cycle",
+        severity="critical",
+        description="cycle",
+        details={"cycle": [1, 2]},
+    )
+    patch_target = "brimstone.monitor._file_repair_issue"
+    with patch(patch_target, return_value="https://github.com/issues/1") as mock_file:
         process_anomalies([anomaly], store, "owner/repo")
         process_anomalies([anomaly], store, "owner/repo")
 
-    # Should only have been called once
+    # Issue should only be filed once
     assert mock_file.call_count == 1
 
 
-def test_process_anomalies_files_critical(tmp_path):
-    """Critical anomaly → file_anomaly_issue called and URL returned."""
+def test_process_anomalies_inline_applies_repair(tmp_path):
     store = _make_store(tmp_path)
     anomaly = Anomaly(
-        kind="dep_cycle", severity="critical", description="cycle!", details={"cycle": [1, 2]}
+        kind="label_drift",
+        severity="warning",
+        description="missing label",
+        details={"issue_number": 5, "bead_state": "claimed", "has_label": False},
     )
-    url = "https://github.com/issues/50"
+    with patch("brimstone.monitor._apply_inline_repair", return_value=True) as mock_repair:
+        with patch("brimstone.monitor._file_repair_issue") as mock_file:
+            process_anomalies([anomaly], store, "owner/repo")
 
-    with patch("brimstone.monitor.file_anomaly_issue", return_value=url) as mock_file:
+    mock_repair.assert_called_once()
+    mock_file.assert_not_called()  # inline: no issue filed on success
+
+
+def test_process_anomalies_inline_escalates_after_max_failures(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="label_drift",
+        severity="warning",
+        description="missing label",
+        details={"issue_number": 5, "bead_state": "claimed", "has_label": False},
+    )
+    with patch("brimstone.monitor._apply_inline_repair", return_value=False):
+        issue_url = "https://github.com/issues/99"
+        with patch("brimstone.monitor._file_repair_issue", return_value=issue_url) as mock_file:
+            for _ in range(INLINE_REPAIR_MAX_ATTEMPTS):
+                process_anomalies([anomaly], store, "owner/repo")
+
+    # Should have escalated and filed exactly once
+    mock_file.assert_called_once()
+
+
+def test_process_anomalies_cleanup_sweep_resolves_gone_anomaly(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="dep_cycle",
+        severity="critical",
+        description="cycle",
+        details={"cycle": [1, 2]},
+    )
+    aid = _anomaly_id(anomaly)
+
+    # First pass: bead created
+    with patch("brimstone.monitor._file_repair_issue", return_value="https://github.com/issues/1"):
+        process_anomalies([anomaly], store, "owner/repo")
+
+    # Second pass: anomaly gone (empty list)
+    with patch("brimstone.monitor._file_repair_issue"):
+        process_anomalies([], store, "owner/repo")
+
+    bead = store.read_anomaly_bead(aid)
+    assert bead is not None
+    assert bead.state == "repaired"
+    assert bead.resolved_at is not None
+
+
+def test_process_anomalies_skips_terminal_beads(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="dep_cycle",
+        severity="critical",
+        description="cycle",
+        details={"cycle": [1, 2]},
+    )
+    aid = _anomaly_id(anomaly)
+
+    # Pre-write a repaired bead
+    existing = AnomalyBead(
+        v=BEAD_SCHEMA_VERSION,
+        anomaly_id=aid,
+        source_repo="owner/repo",
+        kind="dep_cycle",
+        severity="critical",
+        state="repaired",
+        detected_at="2024-01-01T00:00:00+00:00",
+    )
+    store.write_anomaly_bead(existing)
+
+    with patch("brimstone.monitor._file_repair_issue") as mock_file:
+        process_anomalies([anomaly], store, "owner/repo")
+
+    mock_file.assert_not_called()
+
+
+def test_process_anomalies_probe_files_issue(tmp_path):
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="phantom_dep",
+        severity="critical",
+        description="phantom",
+        details={"issue_number": 10, "phantom_dep": 999},
+    )
+    url = "https://github.com/owner/repo/issues/42"
+    with patch("brimstone.monitor._file_repair_issue", return_value=url) as mock_file:
         urls = process_anomalies([anomaly], store, "owner/repo")
 
+    assert urls == [url]
     mock_file.assert_called_once()
-    assert urls == ["https://github.com/issues/50"]
+    aid = _anomaly_id(anomaly)
+    bead = store.read_anomaly_bead(aid)
+    assert bead.gh_issue_number == 42
 
 
 # ---------------------------------------------------------------------------
@@ -414,7 +808,6 @@ def test_process_anomalies_files_critical(tmp_path):
 
 
 def test_run_all_detectors_returns_list(tmp_path):
-    """run_all_detectors always returns a list (no crash even on empty store)."""
     store = _make_store(tmp_path)
     with patch("brimstone.monitor._gh") as mock_gh:
         mock_gh.return_value = _make_gh_result("[]")
@@ -423,7 +816,6 @@ def test_run_all_detectors_returns_list(tmp_path):
 
 
 def test_run_all_detectors_detector_error_caught(tmp_path):
-    """A detector that raises → detector_error anomaly, not a crash."""
     store = _make_store(tmp_path)
 
     def _bad_detector(store, repo):

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -1,0 +1,439 @@
+"""Unit tests for brimstone.monitor."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from brimstone.beads import (
+    BEAD_SCHEMA_VERSION,
+    BeadStore,
+    MergeQueue,
+    MergeQueueEntry,
+    WorkBead,
+)
+from brimstone.monitor import (
+    Anomaly,
+    check_dep_integrity,
+    check_label_drift,
+    check_orphaned_merge,
+    check_pre_pr_zombies,
+    check_state_regressions,
+    process_anomalies,
+    run_all_detectors,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_work_bead(
+    issue_number: int,
+    state: str = "open",
+    stage: str = "impl",
+    milestone: str = "v1.0",
+    branch: str = "",
+    pr_id: str | None = None,
+    claimed_at: str | None = None,
+    blocked_by: list[int] | None = None,
+) -> WorkBead:
+    return WorkBead(
+        v=BEAD_SCHEMA_VERSION,
+        issue_number=issue_number,
+        title=f"Issue #{issue_number}",
+        milestone=milestone,
+        stage=stage,
+        module="cli",
+        priority="P2",
+        state=state,
+        branch=branch or f"{issue_number}-branch",
+        pr_id=pr_id,
+        claimed_at=claimed_at,
+        blocked_by=blocked_by or [],
+    )
+
+
+def _make_store(tmp_path: Path) -> BeadStore:
+    return BeadStore(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Anomaly.fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_anomaly_fingerprint_stable():
+    a = Anomaly(
+        kind="label_drift",
+        severity="warning",
+        description="test",
+        details={"issue_number": 5, "has_label": False},
+    )
+    assert a.fingerprint() == a.fingerprint()
+
+
+def test_anomaly_fingerprint_differs_by_kind():
+    a = Anomaly(kind="label_drift", severity="warning", description="x", details={"n": 1})
+    b = Anomaly(kind="dep_cycle", severity="warning", description="x", details={"n": 1})
+    assert a.fingerprint() != b.fingerprint()
+
+
+def test_anomaly_fingerprint_differs_by_details():
+    a = Anomaly(kind="label_drift", severity="warning", description="x", details={"n": 1})
+    b = Anomaly(kind="label_drift", severity="warning", description="x", details={"n": 2})
+    assert a.fingerprint() != b.fingerprint()
+
+
+# ---------------------------------------------------------------------------
+# check_label_drift
+# ---------------------------------------------------------------------------
+
+
+def _make_gh_result(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess:
+    r = MagicMock(spec=subprocess.CompletedProcess)
+    r.stdout = stdout
+    r.returncode = returncode
+    return r
+
+
+def test_check_label_drift_clean(tmp_path):
+    """No beads, no in-progress labels → no anomalies."""
+    store = _make_store(tmp_path)
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result("[]")
+        anomalies = check_label_drift(store, "owner/repo")
+    assert anomalies == []
+
+
+def test_check_label_drift_claimed_missing_label(tmp_path):
+    """Claimed bead but no in-progress label → label_drift anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(10, state="claimed")
+    store.write_work_bead(bead)
+
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result("[]")
+        anomalies = check_label_drift(store, "owner/repo")
+
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "label_drift"
+    assert anomalies[0].details["issue_number"] == 10
+    assert anomalies[0].details["has_label"] is False
+
+
+def test_check_label_drift_label_no_bead(tmp_path):
+    """in-progress label on issue with no bead → label_drift anomaly."""
+    store = _make_store(tmp_path)
+
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result(json.dumps([{"number": 42}]))
+        anomalies = check_label_drift(store, "owner/repo")
+
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "label_drift"
+    assert anomalies[0].details["issue_number"] == 42
+    assert anomalies[0].details["bead_state"] is None
+
+
+def test_check_label_drift_closed_bead_with_label_is_critical(tmp_path):
+    """Closed bead with in-progress label → critical severity."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(7, state="closed")
+    store.write_work_bead(bead)
+
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result(json.dumps([{"number": 7}]))
+        anomalies = check_label_drift(store, "owner/repo")
+
+    assert len(anomalies) == 1
+    assert anomalies[0].severity == "critical"
+
+
+def test_check_label_drift_clean_claimed_with_label(tmp_path):
+    """Claimed bead AND in-progress label → no anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(5, state="claimed")
+    store.write_work_bead(bead)
+
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result(json.dumps([{"number": 5}]))
+        anomalies = check_label_drift(store, "owner/repo")
+
+    assert anomalies == []
+
+
+# ---------------------------------------------------------------------------
+# check_dep_integrity
+# ---------------------------------------------------------------------------
+
+
+def test_check_dep_integrity_clean(tmp_path):
+    """No deps → no anomalies."""
+    store = _make_store(tmp_path)
+    store.write_work_bead(_make_work_bead(1))
+    assert check_dep_integrity(store) == []
+
+
+def test_check_dep_integrity_phantom_dep(tmp_path):
+    """Bead blocked_by an issue number with no bead → phantom_dep anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(2, blocked_by=[999])
+    store.write_work_bead(bead)
+
+    anomalies = check_dep_integrity(store)
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "phantom_dep"
+    assert anomalies[0].details["phantom_dep"] == 999
+
+
+def test_check_dep_integrity_cycle(tmp_path):
+    """Two beads blocking each other → dep_cycle anomaly."""
+    store = _make_store(tmp_path)
+    store.write_work_bead(_make_work_bead(10, blocked_by=[11]))
+    store.write_work_bead(_make_work_bead(11, blocked_by=[10]))
+
+    anomalies = check_dep_integrity(store)
+    cycle_anomalies = [a for a in anomalies if a.kind == "dep_cycle"]
+    assert len(cycle_anomalies) >= 1
+
+
+def test_check_dep_integrity_closed_phantom_skipped(tmp_path):
+    """Closed bead blocked_by phantom → not flagged (closed beads skip check)."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(3, state="closed", blocked_by=[999])
+    store.write_work_bead(bead)
+
+    anomalies = [a for a in check_dep_integrity(store) if a.kind == "phantom_dep"]
+    assert anomalies == []
+
+
+# ---------------------------------------------------------------------------
+# check_state_regressions
+# ---------------------------------------------------------------------------
+
+
+def test_check_state_regressions_clean(tmp_path):
+    """Normal transitions → no anomalies."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(1)
+    store.write_work_bead(bead)
+    store.append_event("work", "1", None, "open")
+    store.append_event("work", "1", "open", "claimed")
+    store.append_event("work", "1", "claimed", "merge_ready")
+    store.append_event("work", "1", "merge_ready", "closed")
+
+    assert check_state_regressions(store) == []
+
+
+def test_check_state_regressions_bad_transition(tmp_path):
+    """merge_ready → open transition → state_regression anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(1)
+    store.write_work_bead(bead)
+    store.append_event("work", "1", None, "open")
+    store.append_event("work", "1", "open", "claimed")
+    store.append_event("work", "1", "claimed", "merge_ready")
+    store.append_event("work", "1", "merge_ready", "open")  # illegal
+
+    anomalies = check_state_regressions(store)
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "state_regression"
+    assert anomalies[0].details["from_state"] == "merge_ready"
+    assert anomalies[0].details["to_state"] == "open"
+
+
+def test_check_state_regressions_closed_to_open(tmp_path):
+    """closed → open → state_regression anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(2)
+    store.write_work_bead(bead)
+    store.append_event("work", "2", "open", "closed")
+    store.append_event("work", "2", "closed", "open")  # illegal
+
+    anomalies = check_state_regressions(store)
+    assert any(a.kind == "state_regression" for a in anomalies)
+
+
+# ---------------------------------------------------------------------------
+# check_orphaned_merge
+# ---------------------------------------------------------------------------
+
+
+def test_check_orphaned_merge_clean(tmp_path):
+    """merge_ready bead in MergeQueue → no anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(5, state="merge_ready")
+    store.write_work_bead(bead)
+
+    queue = MergeQueue(v=BEAD_SCHEMA_VERSION)
+    queue.queue.append(
+        MergeQueueEntry(
+            pr_number=100, issue_number=5, branch="5-b", enqueued_at="2024-01-01T00:00:00+00:00"
+        )
+    )
+    store.write_merge_queue(queue)
+
+    assert check_orphaned_merge(store) == []
+
+
+def test_check_orphaned_merge_missing_from_queue(tmp_path):
+    """merge_ready bead absent from MergeQueue → orphaned_merge anomaly."""
+    store = _make_store(tmp_path)
+    bead = _make_work_bead(5, state="merge_ready")
+    store.write_work_bead(bead)
+    # Don't add to queue
+
+    anomalies = check_orphaned_merge(store)
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "orphaned_merge"
+    assert anomalies[0].details["issue_number"] == 5
+
+
+def test_check_orphaned_merge_no_merge_ready(tmp_path):
+    """No merge_ready beads → no anomalies."""
+    store = _make_store(tmp_path)
+    store.write_work_bead(_make_work_bead(1, state="open"))
+    assert check_orphaned_merge(store) == []
+
+
+# ---------------------------------------------------------------------------
+# check_pre_pr_zombies
+# ---------------------------------------------------------------------------
+
+
+def test_check_pre_pr_zombies_no_claimed(tmp_path):
+    """No claimed beads → no anomalies."""
+    store = _make_store(tmp_path)
+    assert check_pre_pr_zombies(store) == []
+
+
+def test_check_pre_pr_zombies_fresh_claimed(tmp_path):
+    """Claimed bead claimed recently → no anomaly."""
+    store = _make_store(tmp_path)
+    from datetime import timedelta
+
+    recent = (
+        __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+        - timedelta(minutes=10)
+    ).isoformat()
+    bead = _make_work_bead(3, state="claimed", claimed_at=recent)
+    store.write_work_bead(bead)
+
+    anomalies = check_pre_pr_zombies(store, timeout_minutes=60.0)
+    assert anomalies == []
+
+
+def test_check_pre_pr_zombies_old_no_pr(tmp_path):
+    """Claimed bead older than timeout with no pr_id → pre_pr_zombie anomaly."""
+    store = _make_store(tmp_path)
+    from datetime import timedelta
+
+    old = (
+        __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+        - timedelta(minutes=120)
+    ).isoformat()
+    bead = _make_work_bead(4, state="claimed", claimed_at=old, pr_id=None)
+    store.write_work_bead(bead)
+
+    anomalies = check_pre_pr_zombies(store, timeout_minutes=60.0)
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "pre_pr_zombie"
+    assert anomalies[0].details["issue_number"] == 4
+
+
+def test_check_pre_pr_zombies_has_pr_skipped(tmp_path):
+    """Claimed bead with pr_id → not a zombie."""
+    store = _make_store(tmp_path)
+    from datetime import timedelta
+
+    old = (
+        __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+        - timedelta(minutes=120)
+    ).isoformat()
+    bead = _make_work_bead(5, state="claimed", claimed_at=old, pr_id="pr-200")
+    store.write_work_bead(bead)
+
+    anomalies = check_pre_pr_zombies(store, timeout_minutes=60.0)
+    assert anomalies == []
+
+
+# ---------------------------------------------------------------------------
+# process_anomalies (dedup + filing)
+# ---------------------------------------------------------------------------
+
+
+def test_process_anomalies_dry_run(tmp_path, capsys):
+    """Dry-run mode prints anomalies without calling gh."""
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(kind="test_kind", severity="warning", description="test anomaly")
+
+    with patch("brimstone.monitor.file_anomaly_issue") as mock_file:
+        urls = process_anomalies([anomaly], store, "owner/repo", dry_run=True)
+
+    mock_file.assert_not_called()
+    assert urls == []
+    captured = capsys.readouterr()
+    assert "test_kind" in captured.out
+
+
+def test_process_anomalies_dedup(tmp_path):
+    """Same anomaly filed twice: second call is skipped."""
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(kind="dup_kind", severity="warning", description="dup", details={"x": 1})
+    url = "https://github.com/issues/99"
+
+    with patch("brimstone.monitor.file_anomaly_issue", return_value=url) as mock_file:
+        process_anomalies([anomaly], store, "owner/repo")
+        process_anomalies([anomaly], store, "owner/repo")
+
+    # Should only have been called once
+    assert mock_file.call_count == 1
+
+
+def test_process_anomalies_files_critical(tmp_path):
+    """Critical anomaly → file_anomaly_issue called and URL returned."""
+    store = _make_store(tmp_path)
+    anomaly = Anomaly(
+        kind="dep_cycle", severity="critical", description="cycle!", details={"cycle": [1, 2]}
+    )
+    url = "https://github.com/issues/50"
+
+    with patch("brimstone.monitor.file_anomaly_issue", return_value=url) as mock_file:
+        urls = process_anomalies([anomaly], store, "owner/repo")
+
+    mock_file.assert_called_once()
+    assert urls == ["https://github.com/issues/50"]
+
+
+# ---------------------------------------------------------------------------
+# run_all_detectors
+# ---------------------------------------------------------------------------
+
+
+def test_run_all_detectors_returns_list(tmp_path):
+    """run_all_detectors always returns a list (no crash even on empty store)."""
+    store = _make_store(tmp_path)
+    with patch("brimstone.monitor._gh") as mock_gh:
+        mock_gh.return_value = _make_gh_result("[]")
+        anomalies = run_all_detectors(store, "owner/repo")
+    assert isinstance(anomalies, list)
+
+
+def test_run_all_detectors_detector_error_caught(tmp_path):
+    """A detector that raises → detector_error anomaly, not a crash."""
+    store = _make_store(tmp_path)
+
+    def _bad_detector(store, repo):
+        raise RuntimeError("boom")
+
+    with patch("brimstone.monitor._DETECTORS", [("bad", _bad_detector)]):
+        with patch("brimstone.monitor._gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result("[]")
+            anomalies = run_all_detectors(store, "owner/repo")
+
+    assert len(anomalies) == 1
+    assert anomalies[0].kind == "detector_error"
+    assert "boom" in anomalies[0].description


### PR DESCRIPTION
## Summary

- `brimstone monitor` subcommand + `--monitor` daemon thread flag on `brimstone run`
- Monitor files bugs against brimstone repo (not target repo) via `--bugs-repo`
- Fix: `_monitor_pr` strips `in-progress` label when bead reaches `merge_ready` (closes #268)
- Fix: plan idempotency — counts open+closed issues so already-seeded milestones aren't re-planned (closes #249)
- Refactor: `_check_orphaned_issues` — beads-only, no GitHub fallback, no arbitrary threshold; orphaned claimed beads always warn (resumable), never fatal

## Test plan
- [ ] `uv run pytest tests/unit/` — 565 passed
- [ ] `uv run ruff check src/ tests/` — clean