### PR TITLE
fix: HLD agent must not file LLD issues; fix unit test hangs

### DIFF
--- a/src/brimstone/cli.py
+++ b/src/brimstone/cli.py
@@ -5161,10 +5161,10 @@ def _run_design_worker(
                     f"`docs/design/{milestone}/HLD.md`\n\n"
                     "## Instructions\n"
                     f"Read all merged research docs in `docs/research/{milestone}/`. "
-                    "Write the HLD. "
-                    "For each module identified, file a `Design: LLD for <module>` "
-                    "issue with label `stage/design` and this milestone. "
-                    "Check for duplicates before filing."
+                    "Write the HLD following the skill instructions.\n\n"
+                    "**Do NOT file LLD issues.** The orchestrator parses `### Module:` "
+                    "headings from the merged HLD and creates LLD issues via bead-based "
+                    "dedup after this PR merges."
                 ),
                 store=store,
             )

--- a/src/brimstone/skills/design-worker-hld.md
+++ b/src/brimstone/skills/design-worker-hld.md
@@ -1,4 +1,4 @@
-Write the High-Level Design (HLD) document for a milestone and file LLD issues for each module.
+Write the High-Level Design (HLD) document for a milestone.
 
 **Do NOT use the Agent tool. Do NOT spawn sub-agents.**
 
@@ -115,44 +115,7 @@ git commit -m "docs: add HLD for <milestone> (Closes #<issue_number>) [skip ci]"
 git push -u origin <branch>
 ```
 
-### Step 4 — File LLD Issues
-
-For each module identified in the HLD, check for a duplicate then file a `stage/design` issue:
-
-```bash
-# Fetch existing issue titles scoped to this milestone to check for dups
-# IMPORTANT: scope to --milestone so closed issues from prior milestones
-# (e.g. "Design: LLD for lexer" from v0.1.0) don't suppress creation here.
-EXISTING=$(gh issue list --repo <owner>/<repo> --state all --milestone "<milestone>" --limit 500 --json title --jq '.[].title')
-
-for MODULE in <module1> <module2> ...; do
-  TITLE="Design: LLD for $MODULE"
-  if echo "$EXISTING" | grep -qxF "$TITLE"; then
-    echo "Issue '$TITLE' already exists — skipping"
-  else
-    gh issue create \
-      --repo <owner>/<repo> \
-      --title "$TITLE" \
-      --label "stage/design" \
-      --milestone "<milestone>" \
-      --body "$(cat <<EOF
-## Deliverable
-\`docs/design/lld/$MODULE.md\`
-
-## Inputs
-- HLD: \`docs/design/<milestone>/HLD.md\`
-- Research docs: \`docs/research/<milestone>/\`
-
-## Acceptance Criteria
-The LLD must cover: data structures, key algorithms, public API/interfaces, error
-handling, and test strategy for this module.
-EOF
-)"
-  fi
-done
-```
-
-### Step 5 — Create PR
+### Step 4 — Create PR
 
 ```bash
 DEFAULT_BRANCH=$(gh repo view --repo <owner>/<repo> --json defaultBranchRef --jq '.defaultBranchRef.name')
@@ -163,7 +126,7 @@ gh pr create \
   --base $DEFAULT_BRANCH
 ```
 
-### Step 6 — STOP
+### Step 5 — STOP
 
 Do not merge. The orchestrator monitors the PR and merges when CI passes.
 
@@ -171,7 +134,9 @@ Do not merge. The orchestrator monitors the PR and merges when CI passes.
 
 - **One PR, one doc**: this agent produces only `docs/design/<milestone>/HLD.md`
 - **Milestone-scoped paths**: all paths use `<milestone>` as the directory name, not a generic folder
-- **LLD issues use exact module names**: the names here become file paths
-  (`docs/design/<milestone>/lld/<module>.md`) and must be filesystem-safe
+- **Module names are file paths**: names in `### Module: <name>` headings become paths
+  (`docs/design/<milestone>/lld/<name>.md`) — use filesystem-safe names
 - **No implementation code**: this agent writes documentation only
-- **Check for dup LLD issues** before filing — re-runs must be safe
+- **Do NOT file LLD issues**: the orchestrator parses `### Module:` headings from the merged HLD
+  and files LLD issues itself using bead-based dedup. Filing them here causes duplicates due to
+  GitHub's eventual consistency.

--- a/tests/unit/test_cli_design.py
+++ b/tests/unit/test_cli_design.py
@@ -127,7 +127,8 @@ _DESIGN_PATCHES = {
     "list_research": "brimstone.cli._list_all_open_issues_by_label",
     "classify_blocking": "brimstone.cli._classify_blocking_issues",
     "default_branch": "brimstone.cli._get_default_branch_for_repo",
-    "repo_root": "brimstone.cli._get_repo_root",
+    "repo_root": "brimstone.cli._ensure_worktree_repo",
+    "parse_modules": "brimstone.cli._parse_modules_from_hld",
     "doc_exists": "brimstone.cli._doc_exists_on_default_branch",
     "list_design": "brimstone.cli._list_open_issues_by_label",
     "file_design": "brimstone.cli._file_design_issue_if_missing",
@@ -184,8 +185,9 @@ class TestDesignWorkerGate1:
             patch(_DESIGN_PATCHES["classify_blocking"], side_effect=_classify_side_effect),
             patch("brimstone.cli.time.sleep"),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], return_value=True),
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch(_DESIGN_PATCHES["file_design"]),
             patch(_DESIGN_PATCHES["list_design"], return_value=[]),
             patch(_DESIGN_PATCHES["log_event"]),
@@ -222,9 +224,13 @@ class TestDesignWorkerGate1:
 
         with (
             patch(_DESIGN_PATCHES["list_research"], return_value=v2_only),
+            # classify_blocking must be patched: store=None means [DEFERRED] body tag is
+            # not checked (bead-only check), so without this patch Gate 1 loops forever.
+            patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], v2_only)),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], return_value=True),  # HLD exists → skip Phase 1
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch(_DESIGN_PATCHES["list_design"], return_value=[]),
             patch(_DESIGN_PATCHES["log_event"]),
             patch(_DESIGN_PATCHES["save_session"]),
@@ -246,10 +252,12 @@ class TestDesignWorkerGate1:
         checkpoint = make_checkpoint()
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], return_value=True),  # HLD exists → skip Phase 1
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch(_DESIGN_PATCHES["list_design"], return_value=[]),
             patch(_DESIGN_PATCHES["log_event"]),
             patch(_DESIGN_PATCHES["save_session"]),
@@ -315,10 +323,12 @@ class TestDesignWorkerPhase1:
         lld_issue = make_design_issue(20, "Design: LLD for parser")
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], side_effect=doc_exists),
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch(_DESIGN_PATCHES["list_design"], return_value=[lld_issue]),
             patch(_DESIGN_PATCHES["dispatch_agent"]) as mock_dispatch,
             patch(_DESIGN_PATCHES["claim"]),
@@ -365,10 +375,12 @@ class TestDesignWorkerPhase1:
             return []
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], side_effect=doc_exists),
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch(_DESIGN_PATCHES["list_design"], side_effect=list_design),
             patch(_DESIGN_PATCHES["file_design"]),
             patch(_DESIGN_PATCHES["claim"]),
@@ -411,9 +423,10 @@ class TestDesignWorkerPhase1:
         hld_issue = make_design_issue(10, "Design: HLD for v1")
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], return_value=False),
             patch("brimstone.cli._list_open_issues_by_label", return_value=[hld_issue]),
             patch(_DESIGN_PATCHES["claim"]),
@@ -451,9 +464,10 @@ class TestDesignWorkerPhase1:
 
         # Simulate: HLD was skipped (no issue found) but doc still not on branch
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], return_value=False),
             patch("brimstone.cli._list_open_issues_by_label", return_value=[]),
             patch(_DESIGN_PATCHES["file_design"]),
@@ -509,10 +523,12 @@ class TestDesignWorkerPhase2:
             return "HLD" in path  # HLD present, no LLD docs yet
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], side_effect=doc_exists),
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch(
                 "brimstone.cli._list_open_issues_by_label",
                 return_value=lld_issues,
@@ -564,10 +580,12 @@ class TestDesignWorkerPhase2:
             return "HLD" in path or "parser" in path
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], side_effect=doc_exists),
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch("brimstone.cli._list_open_issues_by_label", return_value=lld_issues),
             patch(_DESIGN_PATCHES["claim"]),
             patch(_DESIGN_PATCHES["create_wt"], return_value="/wt/21"),
@@ -603,10 +621,12 @@ class TestDesignWorkerPhase2:
         checkpoint = make_checkpoint()
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], return_value=True),  # HLD present
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch("brimstone.cli._list_open_issues_by_label", return_value=[]),
             patch(_DESIGN_PATCHES["log_event"]),
             patch(_DESIGN_PATCHES["save_session"]),
@@ -635,10 +655,12 @@ class TestDesignWorkerPhase2:
             return "HLD" in path
 
         with (
+            patch(_DESIGN_PATCHES["list_research"], return_value=[]),
             patch(_DESIGN_PATCHES["classify_blocking"], return_value=([], [])),
             patch(_DESIGN_PATCHES["default_branch"], return_value="main"),
-            patch(_DESIGN_PATCHES["repo_root"], return_value="/repo"),
+            patch(_DESIGN_PATCHES["repo_root"], return_value=("/repo", None)),
             patch(_DESIGN_PATCHES["doc_exists"], side_effect=doc_exists),
+            patch(_DESIGN_PATCHES["parse_modules"], return_value=[]),
             patch("brimstone.cli._list_open_issues_by_label", return_value=[lld_issue]),
             patch(_DESIGN_PATCHES["claim"]),
             patch(_DESIGN_PATCHES["create_wt"], return_value="/wt/20"),


### PR DESCRIPTION
## Summary

- **Root cause of duplicate LLD issues**: HLD agent was instructed to file LLD issues via `gh issue create` directly. GitHub's eventual consistency means a freshly-created issue isn't indexed yet, so the agent's duplicate check via `gh issue list` missed them and filed duplicates. The orchestrator's Phase 2 self-heal already handles this correctly using bead-based dedup — removed the agent-side filing entirely.

- **HLD issue body**: Removed the "file LLD issues" instruction. Added explicit note that the orchestrator handles it after the HLD merges.

- **`design-worker-hld.md` skill**: Removed Step 4 (File LLD Issues). Added constraint note explaining why agents must not file LLD issues.

- **Test hangs fixed**: `_DESIGN_PATCHES["repo_root"]` was patching `_get_repo_root` (unused in `_run_design_worker`) instead of `_ensure_worktree_repo` (which makes a real `gh repo clone` call). Fixed to patch the right function with the correct tuple return value. Added `parse_modules` and `list_research` patches to all tests that reach Phase 2 or Gate 1 to eliminate real network calls.

- **Infinite Gate 1 loop fixed**: `test_proceeds_when_only_deferred_research_remain` didn't patch `_classify_blocking_issues`. Since `_classify_blocking_issues` is now bead-only (no `[DEFERRED]` body tag check when `store=None`), the deferred issue was classified as blocking and Gate 1 looped forever.

## Test plan
- [x] `uv run pytest tests/unit/test_cli_design.py` — 18 passed, 2.80s (was hanging)
- [x] `uv run pytest tests/unit/` — 565 passed, 74s

🤖 Generated with [Claude Code](https://claude.com/claude-code)